### PR TITLE
Fix multiple sessions per process

### DIFF
--- a/VolumeControl.Core/Config.cs
+++ b/VolumeControl.Core/Config.cs
@@ -361,6 +361,10 @@ namespace VolumeControl.Core
         /// </summary>
         public bool LockTargetSession { get; set; } = false;
         /// <summary>
+        /// Hide inactive sessions from notification and hotkey navigation.
+        /// </summary>
+        public bool HideInactiveSessions { get; set; } = true;
+        /// <summary>
         /// Gets or sets the target device ID.
         /// </summary>
         public string TargetDeviceID { get; set; } = string.Empty;

--- a/VolumeControl.Core/NotificationConfigSection.cs
+++ b/VolumeControl.Core/NotificationConfigSection.cs
@@ -87,6 +87,10 @@ namespace VolumeControl.Core
         /// </summary>
         public Color UnlockedColor { get; set; } = Color.FromRgb(0x49, 0x6D, 0x49);
         /// <summary>
+        /// Gets or sets the accent color when selection is active.
+        /// </summary>
+        public Color ActiveColor { get; set; } = Color.FromRgb(0x49, 0x89, 0xC3);
+        /// <summary>
         /// Gets or sets the text color.
         /// </summary>
         public Color TextColor { get; set; } = Colors.WhiteSmoke;

--- a/VolumeControl.CoreAudio/AudioDevice.cs
+++ b/VolumeControl.CoreAudio/AudioDevice.cs
@@ -24,6 +24,7 @@ namespace VolumeControl.CoreAudio
             Name = mmDevice.GetDeviceName();
             ID = mmDevice.ID;
             DataFlow = MMDevice.DataFlow;
+            IsDefault = MMDevice.Selected;
 
             if (MMDevice.AudioSessionManager2 is null)
                 throw new NullReferenceException($"{nameof(AudioDevice)} '{Name}' has a null {nameof(MMDevice.AudioSessionManager2)} property!");

--- a/VolumeControl.CoreAudio/AudioDeviceSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioDeviceSessionManager.cs
@@ -178,11 +178,11 @@ namespace VolumeControl.CoreAudio
             {
                 if (CreateAndAddSessionIfUnique(audioSessionControl) is AudioSession newAudioSession)
                 {
-                    FLog.Debug($"New {nameof(AudioSession)} '{newAudioSession.ProcessName}' ({newAudioSession.PID}) created; successfully added it to the list.");
+                    FLog.Debug($"New {nameof(AudioSession)} '{newAudioSession.ProcessName}' ({newAudioSession.PID}) {newAudioSession.SessionIdentifier} created; successfully added it to the list.");
                 }
                 else if (FindSessionByAudioSessionControl(audioSessionControl) is AudioSession existingSession)
                 {
-                    FLog.Error($"New {nameof(AudioSession)} '{existingSession?.ProcessName}' ({existingSession?.PID}) created; but it was already in the list!");
+                    FLog.Error($"New {nameof(AudioSession)} '{existingSession?.ProcessName}' ({existingSession?.PID}) {existingSession?.SessionIdentifier} created; but it was already in the list!");
                 }
             }
             else

--- a/VolumeControl.CoreAudio/AudioSession.cs
+++ b/VolumeControl.CoreAudio/AudioSession.cs
@@ -266,6 +266,19 @@ namespace VolumeControl.CoreAudio
             }
         }
         private bool _isHidden;
+        /// <summary>
+        /// Gets or sets whether this session is selected in the <see cref="AudioSessionMultiSelector"/>.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                _isSelected = value;
+                NotifyPropertyChanged();
+            }
+        }
+        private bool _isSelected;
         #endregion IHideableAudioControl Properties
 
         #region Methods

--- a/VolumeControl.CoreAudio/AudioSession.cs
+++ b/VolumeControl.CoreAudio/AudioSession.cs
@@ -123,6 +123,26 @@ namespace VolumeControl.CoreAudio
         /// </summary>
         public string DeviceName => AudioDevice.Name;
         /// <summary>
+        /// Gets the name of this <see cref="AudioSession"/> instance with a device name and flow direction.
+        /// </summary>
+        public string FlowName
+        {
+            get
+            {
+                return Name + (AudioDevice.DataFlow == DataFlow.Capture ? " ← " : " → ") + AudioDevice.Name;
+            }
+        }
+        /// <summary>
+        /// Gets the device name of this <see cref="AudioSession"/> instance with a flow direction.
+        /// </summary>
+        public string DeviceFlowName
+        {
+            get
+            {
+                return (AudioDevice.DataFlow == DataFlow.Capture ? "← " : "→ ") + AudioDevice.Name;
+            }
+        }
+        /// <summary>
         /// Gets the process ID of the process associated with this <see cref="AudioSession"/> instance.
         /// </summary>
         public uint PID { get; }

--- a/VolumeControl.CoreAudio/AudioSession.cs
+++ b/VolumeControl.CoreAudio/AudioSession.cs
@@ -129,7 +129,7 @@ namespace VolumeControl.CoreAudio
         {
             get
             {
-                return Name + (AudioDevice.DataFlow == DataFlow.Capture ? " ← " : " → ") + AudioDevice.Name;
+                return Name + (AudioDevice.DataFlow == DataFlow.Capture ? " 🠈 " : " 🠊 ") + AudioDevice.Name;
             }
         }
         /// <summary>
@@ -139,7 +139,7 @@ namespace VolumeControl.CoreAudio
         {
             get
             {
-                return (AudioDevice.DataFlow == DataFlow.Capture ? "← " : "→ ") + AudioDevice.Name;
+                return (AudioDevice.DataFlow == DataFlow.Capture ? "🠈 " : "🠊 ") + AudioDevice.Name;
             }
         }
         /// <summary>

--- a/VolumeControl.CoreAudio/AudioSession.cs
+++ b/VolumeControl.CoreAudio/AudioSession.cs
@@ -115,6 +115,10 @@ namespace VolumeControl.CoreAudio
         /// </summary>
         public DataFlow DataFlow => AudioDevice.DataFlow;
         /// <summary>
+        /// Gets the AudioSessionState of this audio session.
+        /// </summary>
+        public AudioSessionState State => AudioSessionControl.State;
+        /// <summary>
         /// Gets the process ID of the process associated with this <see cref="AudioSession"/> instance.
         /// </summary>
         public uint PID { get; }
@@ -399,7 +403,10 @@ namespace VolumeControl.CoreAudio
         /// Triggers the <see cref="StateChanged"/> event.
         /// </summary>
         private void AudioSessionControl_OnStateChanged(object sender, AudioSessionState newState)
-            => NotifyStateChanged(newState);
+        {
+            NotifyStateChanged(newState);
+            NotifyPropertyChanged(nameof(State));
+        }
         #endregion AudioSessionControl
 
         #endregion EventHandlers

--- a/VolumeControl.CoreAudio/AudioSession.cs
+++ b/VolumeControl.CoreAudio/AudioSession.cs
@@ -119,6 +119,10 @@ namespace VolumeControl.CoreAudio
         /// </summary>
         public AudioSessionState State => AudioSessionControl.State;
         /// <summary>
+        /// Gets the device name of the device associated with this <see cref="AudioSession"/> instance.
+        /// </summary>
+        public string DeviceName => AudioDevice.Name;
+        /// <summary>
         /// Gets the process ID of the process associated with this <see cref="AudioSession"/> instance.
         /// </summary>
         public uint PID { get; }

--- a/VolumeControl.CoreAudio/AudioSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioSessionManager.cs
@@ -222,7 +222,7 @@ namespace VolumeControl.CoreAudio
         /// </summary>
         /// <remarks>
         /// Note that this method checks ONLY the <see cref="AudioSession.ProcessName"/> property, which can differ from the name shown in the UI (<see cref="AudioSession.Name"/>)!<br/>
-        /// To check both properties, use <see cref="FindSessionWithName(string, StringComparison, bool)"/> instead.
+        /// To check both properties, use <see cref="FindSessionWithName(string, StringComparison, bool, bool)"/> instead.
         /// </remarks>
         /// <param name="processName">A Process Name to search for. See <see cref="AudioSession.ProcessName"/>.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process name strings.</param>

--- a/VolumeControl.CoreAudio/AudioSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioSessionManager.cs
@@ -20,7 +20,6 @@ namespace VolumeControl.CoreAudio
         {
             _sessionManagers = new();
             _sessions = new();
-            _hiddenSessions = new();
         }
         /// <summary>
         /// Creates a new <see cref="AudioSessionManager"/> instance with the given <paramref name="sessionManagers"/>.
@@ -144,11 +143,13 @@ namespace VolumeControl.CoreAudio
         /// <summary>
         /// Gets the list of hidden <see cref="AudioSession"/> instances (<see cref="AudioSession.IsHidden"/>) currently being managed by this <see cref="AudioSessionManager"/> instance.
         /// </summary>
-        public IReadOnlyList<AudioSession> HiddenSessions => _hiddenSessions;
-        /// <summary>
-        /// The underlying <see cref="List{T}"/> for the <see cref="HiddenSessions"/> property.
-        /// </summary>
-        private readonly List<AudioSession> _hiddenSessions;
+        public IReadOnlyList<AudioSession> HiddenSessions
+        {
+            get
+            {
+                return _sessions; //TODO
+            }
+        }
         #endregion Properties
 
         #region Methods
@@ -178,15 +179,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.PID == processId && session.DataFlow == dataFlow && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.PID == processId && session.DataFlow == dataFlow && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-                }
+                if (session.PID == processId && session.DataFlow == dataFlow && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -202,15 +195,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.PID == processId && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.PID == processId && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-                }
+                if (session.PID == processId && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -236,15 +221,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.ProcessName.Equals(processName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.ProcessName.Equals(processName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-                }
+                if (session.ProcessName.Equals(processName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -267,17 +244,8 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden))
                     return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
-                        return session;
-                }
             }
             return null;
         }
@@ -296,17 +264,8 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden))
                     return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
-                        return session;
-                }
             }
             return null;
         }
@@ -329,17 +288,8 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden))
                     sessions.Add(session);
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
-                        sessions.Add(session);
-                }
             }
             return sessions;
         }
@@ -361,15 +311,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-                }
+                if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -417,8 +359,8 @@ namespace VolumeControl.CoreAudio
                 string name = segments[1];
 
                 if (uint.TryParse(segments[0], out uint pid)
-                    && FindSessionWithPID(pid, dataFlow, includeHiddenSessions) is AudioSession session
-                    && session.HasMatchingName(name, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                    && FindSessionWithPID(pid, dataFlow, includeHiddenSessions, includeInactiveSessions) is AudioSession session
+                    && session.HasMatchingName(name, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden))
                 { // found a session with a matching process ID and ProcessName
                     return session;
                 }
@@ -453,15 +395,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
-                }
+                if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -482,15 +416,7 @@ namespace VolumeControl.CoreAudio
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.SessionInstanceIdentifier.Equals(sessionInstanceIdentifier, stringComparison)) return session;
-            }
-            if (includeHiddenSessions)
-            {
-                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
-                {
-                    AudioSession session = HiddenSessions[i];
-                    if (session.SessionInstanceIdentifier.Equals(sessionInstanceIdentifier, stringComparison)) return session;
-                }
+                if (session.SessionInstanceIdentifier.Equals(sessionInstanceIdentifier, stringComparison) && (includeHiddenSessions || !session.IsHidden)) return session;
             }
             return null;
         }
@@ -514,7 +440,7 @@ namespace VolumeControl.CoreAudio
             if (session.IsHidden)
             { // add session to hidden list
                 NotifyAddingSessionToHiddenList(session);
-                _hiddenSessions.Add(session);
+                _sessions.Add(session);
                 NotifyAddedSessionToHiddenList(session);
             }
             else
@@ -531,17 +457,17 @@ namespace VolumeControl.CoreAudio
         internal void RemoveSession(AudioSession session)
         {
             // AudioSession.IsHidden is not reliable within this method
-            if (HiddenSessions.IndexOf(session, out int hiddenIndex))
+            if (Sessions.IndexOf(session, out int hiddenIndex))
             {
-                NotifyRemovingSessionFromHiddenList(session);
-                _hiddenSessions.RemoveAt(hiddenIndex);
-                NotifyRemovedSessionFromHiddenList(session);
-            }
-            else if (Sessions.IndexOf(session, out int index))
-            {
-                NotifyRemovingSessionFromList(session);
-                _sessions.RemoveAt(index);
-                NotifyRemovedSessionFromList(session);
+                if (session.IsHidden)
+                    NotifyRemovingSessionFromHiddenList(session);
+                else
+                    NotifyRemovingSessionFromList(session);
+                _sessions.RemoveAt(hiddenIndex);
+                if (session.IsHidden)
+                    NotifyRemovedSessionFromHiddenList(session);
+                else
+                    NotifyRemovedSessionFromList(session);
             }
         }
         #endregion Add/Remove Session
@@ -603,10 +529,11 @@ namespace VolumeControl.CoreAudio
         {
             if (session.IsHidden) return; //< don't do anything if the session is already hidden
 
+            NotifyRemovingSessionFromList(session);
+            NotifyAddingSessionToHiddenList(session);
             session.IsHidden = true;
-
-            RemoveSession(session); //< remove from the Sessions list
-            AddSession(session); //< add to the HiddenSessions list
+            NotifyRemovedSessionFromHiddenList(session);
+            NotifyAddedSessionToList(session);
         }
         /// <summary>
         /// Unhides the specified <paramref name="session"/> by moving it from the <see cref="HiddenSessions"/> list to the <see cref="Sessions"/> list.
@@ -616,10 +543,11 @@ namespace VolumeControl.CoreAudio
         {
             if (!session.IsHidden) return; //< don't do anything if the session isn't hidden
 
+            NotifyRemovingSessionFromHiddenList(session);
+            NotifyAddingSessionToList(session);
             session.IsHidden = false;
-
-            RemoveSession(session); //< remove from the HiddenSessions list
-            AddSession(session); //< add to the Sessions list
+            NotifyRemovedSessionFromList(session);
+            NotifyAddedSessionToHiddenList(session);
         }
         #endregion Hide/Unhide Session
 
@@ -651,7 +579,6 @@ namespace VolumeControl.CoreAudio
         public void Dispose()
         {
             Sessions.DisposeAll();
-            HiddenSessions.DisposeAll();
             SessionManagers.DisposeAll();
             GC.SuppressFinalize(this);
         }

--- a/VolumeControl.CoreAudio/AudioSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioSessionManager.cs
@@ -312,6 +312,39 @@ namespace VolumeControl.CoreAudio
         }
         #endregion FindSessionWithName
 
+        #region FindSessionsWithName
+        /// <summary>
+        /// Finds all audio sessions whose owning process has the given <paramref name="sessionName"/>.
+        /// </summary>
+        /// <param name="sessionName">A Name or Process Name to search for. See <see cref="AudioSession.Name"/> &amp; <see cref="AudioSession.ProcessName"/>.</param>
+        /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process name strings.</param>
+        /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
+        /// <returns>List of <see cref="AudioSession"/> with the given <paramref name="sessionName"/>.</returns>
+        public List<AudioSession> FindSessionsWithName(string sessionName, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
+        {
+            List<AudioSession> sessions = new();
+            if (sessionName.Length == 0) return sessions;
+
+            for (int i = 0, max = Sessions.Count; i < max; ++i)
+            {
+                AudioSession session = Sessions[i];
+                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                    sessions.Add(session);
+            }
+            if (includeHiddenSessions)
+            {
+                for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
+                {
+                    AudioSession session = HiddenSessions[i];
+                    if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                        sessions.Add(session);
+                }
+            }
+            return sessions;
+        }
+        #endregion FindSessionWithName
+
         #region FindSessionWithExactProcessIdentifier
         /// <summary>
         /// Finds the audio session with the given <paramref name="processIdentifier"/>.

--- a/VolumeControl.CoreAudio/AudioSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioSessionManager.cs
@@ -357,7 +357,7 @@ namespace VolumeControl.CoreAudio
             // remove preceding/trailing whitespace & colons (separator char)
             string s = processIdentifier.Trim(AudioSession.ProcessIdentifierSeparatorChar, ' ', '\t', '\v', '\r', '\n');
             if (s.Length == 0) return null;
-            
+
             var segments = s.Split(AudioSession.ProcessIdentifierSeparatorChar, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
             // parse the data flow segment
@@ -462,7 +462,7 @@ namespace VolumeControl.CoreAudio
         /// <param name="session">An <see cref="AudioSession"/> instance to add to the list.</param>
         internal void AddSession(AudioSession session)
         {
-            if (_sessions.Any(s => s.PID.Equals(session.PID) && s.DataFlow.Equals(session.DataFlow)))
+            if (_sessions.Any(s => s.PID.Equals(session.PID) && s.DataFlow.Equals(session.DataFlow) && s.SessionIdentifier.Equals(session.SessionIdentifier)))
                 return; // don't add duplicate sessions
 
             // allow handlers to edit the session's initial name:

--- a/VolumeControl.CoreAudio/AudioSessionManager.cs
+++ b/VolumeControl.CoreAudio/AudioSessionManager.cs
@@ -171,20 +171,21 @@ namespace VolumeControl.CoreAudio
         /// <param name="processId">A Process ID to search for. See <see cref="AudioSession.PID"/>.</param>
         /// <param name="dataFlow">The data flow type of the session to search for.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The <see cref="AudioSession"/> with the given <paramref name="processId"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithPID(uint processId, DataFlow? dataFlow, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithPID(uint processId, DataFlow? dataFlow, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         { // don't use FindSession here, this way is more than 2x faster:
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.PID == processId && session.DataFlow == dataFlow) return session;
+                if (session.PID == processId && session.DataFlow == dataFlow && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
             }
             if (includeHiddenSessions)
             {
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.PID == processId && session.DataFlow == dataFlow) return session;
+                    if (session.PID == processId && session.DataFlow == dataFlow && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
                 }
             }
             return null;
@@ -194,20 +195,21 @@ namespace VolumeControl.CoreAudio
         /// </summary>
         /// <param name="processId">A Process ID to search for. See <see cref="AudioSession.PID"/>.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The <see cref="AudioSession"/> with the given <paramref name="processId"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithPID(uint processId, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithPID(uint processId, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         { // don't use FindSession here, this way is more than 2x faster:
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.PID == processId) return session;
+                if (session.PID == processId && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
             }
             if (includeHiddenSessions)
             {
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.PID == processId) return session;
+                    if (session.PID == processId && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
                 }
             }
             return null;
@@ -225,22 +227,23 @@ namespace VolumeControl.CoreAudio
         /// <param name="processName">A Process Name to search for. See <see cref="AudioSession.ProcessName"/>.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process name strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The first <see cref="AudioSession"/> with the given <paramref name="processName"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithProcessName(string processName, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithProcessName(string processName, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             if (processName.Length == 0) return null;
 
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.ProcessName.Equals(processName, stringComparison)) return session;
+                if (session.ProcessName.Equals(processName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
             }
             if (includeHiddenSessions)
             {
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.ProcessName.Equals(processName, stringComparison)) return session;
+                    if (session.ProcessName.Equals(processName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
                 }
             }
             return null;
@@ -255,15 +258,16 @@ namespace VolumeControl.CoreAudio
         /// <param name="dataFlow">The data flow type of the session to search for.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process name strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The first <see cref="AudioSession"/> with the given <paramref name="sessionName"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithName(string sessionName, DataFlow? dataFlow, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithName(string sessionName, DataFlow? dataFlow, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             if (sessionName.Length == 0) return null;
 
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison))
+                if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
                     return session;
             }
             if (includeHiddenSessions)
@@ -271,7 +275,7 @@ namespace VolumeControl.CoreAudio
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison))
+                    if ((dataFlow == null || session.DataFlow == dataFlow) && session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
                         return session;
                 }
             }
@@ -283,15 +287,16 @@ namespace VolumeControl.CoreAudio
         /// <param name="sessionName">A Name or Process Name to search for. See <see cref="AudioSession.Name"/> &amp; <see cref="AudioSession.ProcessName"/>.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process name strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The first <see cref="AudioSession"/> with the given <paramref name="sessionName"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithName(string sessionName, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithName(string sessionName, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             if (sessionName.Length == 0) return null;
 
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.HasMatchingName(sessionName, stringComparison))
+                if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
                     return session;
             }
             if (includeHiddenSessions)
@@ -299,7 +304,7 @@ namespace VolumeControl.CoreAudio
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.HasMatchingName(sessionName, stringComparison))
+                    if (session.HasMatchingName(sessionName, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
                         return session;
                 }
             }
@@ -314,22 +319,23 @@ namespace VolumeControl.CoreAudio
         /// <param name="processIdentifier">A Process Identifier to search for. See <see cref="AudioSession.ProcessIdentifier"/>.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing process identifier strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The <see cref="AudioSession"/> with the given <paramref name="processIdentifier"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithExactProcessIdentifier(string processIdentifier, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithExactProcessIdentifier(string processIdentifier, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             if (processIdentifier.Length == 0) return null;
 
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison)) return session;
+                if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
             }
             if (includeHiddenSessions)
             {
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison)) return session;
+                    if (session.ProcessIdentifier.Equals(processIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
                 }
             }
             return null;
@@ -347,12 +353,13 @@ namespace VolumeControl.CoreAudio
         /// Supports partial identifiers that only include the PID or ProcessName component, with or without the separator character.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>
         /// An <see cref="AudioSession"/> that matches - or is similar to - the given <paramref name="processIdentifier"/> if found; otherwise <see langword="null"/>.
         /// <br/>
         /// The returned session can have a different PID than the one specified by the <paramref name="processIdentifier"/>.
         /// </returns>
-        public AudioSession? FindSessionWithSimilarProcessIdentifier(string processIdentifier, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithSimilarProcessIdentifier(string processIdentifier, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             // remove preceding/trailing whitespace & colons (separator char)
             string s = processIdentifier.Trim(AudioSession.ProcessIdentifierSeparatorChar, ' ', '\t', '\v', '\r', '\n');
@@ -378,20 +385,20 @@ namespace VolumeControl.CoreAudio
 
                 if (uint.TryParse(segments[0], out uint pid)
                     && FindSessionWithPID(pid, dataFlow, includeHiddenSessions) is AudioSession session
-                    && session.HasMatchingName(name, stringComparison))
+                    && session.HasMatchingName(name, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
                 { // found a session with a matching process ID and ProcessName
                     return session;
                 }
-                else return FindSessionWithName(name, dataFlow, stringComparison, includeHiddenSessions);
+                else return FindSessionWithName(name, dataFlow, stringComparison, includeHiddenSessions, includeInactiveSessions);
             }
             else
             { // only 1 segment is present
                 s = segments[0];
                 if (s.All(char.IsNumber))
-                    return FindSessionWithPID(uint.Parse(s), includeHiddenSessions);
+                    return FindSessionWithPID(uint.Parse(s), includeHiddenSessions, includeInactiveSessions);
                 else
                 { // ProcessName segment is present:
-                    return FindSessionWithName(s, stringComparison, includeHiddenSessions); //< check both Name & ProcessName
+                    return FindSessionWithName(s, stringComparison, includeHiddenSessions, includeInactiveSessions); //< check both Name & ProcessName
                 }
             }
         }
@@ -404,22 +411,23 @@ namespace VolumeControl.CoreAudio
         /// <param name="sessionIdentifier">A SessionIdentifier string to search for. See <see cref="AudioSession.SessionIdentifier"/>.</param>
         /// <param name="stringComparison">The <see cref="StringComparison"/> type to use when comparing session identifier strings.</param>
         /// <param name="includeHiddenSessions">When <see langword="true"/>, also searches the hidden sessions; otherwise when <see langword="false"/>, only searches through visible sessions.</param>
+        /// <param name="includeInactiveSessions">When <see langword="true"/>, also searches the inactive sessions; otherwise when <see langword="false"/>, only searches through active sessions.</param>
         /// <returns>The first <see cref="AudioSession"/> with the given <paramref name="sessionIdentifier"/> if found; otherwise <see langword="null"/>.</returns>
-        public AudioSession? FindSessionWithSessionIdentifier(string sessionIdentifier, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false)
+        public AudioSession? FindSessionWithSessionIdentifier(string sessionIdentifier, StringComparison stringComparison = StringComparison.Ordinal, bool includeHiddenSessions = false, bool includeInactiveSessions = true)
         {
             if (sessionIdentifier.Length == 0) return null;
 
             for (int i = 0, max = Sessions.Count; i < max; ++i)
             {
                 AudioSession session = Sessions[i];
-                if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison)) return session;
+                if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
             }
             if (includeHiddenSessions)
             {
                 for (int i = 0, max = HiddenSessions.Count; i < max; ++i)
                 {
                     AudioSession session = HiddenSessions[i];
-                    if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison)) return session;
+                    if (session.SessionIdentifier.Equals(sessionIdentifier, stringComparison) && (includeInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive)) return session;
                 }
             }
             return null;

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -476,6 +476,8 @@ namespace VolumeControl.CoreAudio
             if (Settings.HideInactiveSessions)
             {
                 int oldIndex = CurrentIndex;
+                if (oldIndex == -1)
+                    oldIndex = 0;
                 do
                 {
                     CurrentIndex = (CurrentIndex + 1) % SelectionStates.Count;
@@ -505,6 +507,8 @@ namespace VolumeControl.CoreAudio
             if (Settings.HideInactiveSessions)
             {
                 int oldIndex = CurrentIndex;
+                if (oldIndex == -1)
+                    oldIndex = 0;
                 do
                 {
                     CurrentIndex = (SelectionStates.Count + CurrentIndex - 1) % SelectionStates.Count;

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -526,7 +526,7 @@ namespace VolumeControl.CoreAudio
         {
             foreach (var session in Sessions)
             {
-                if (!session.IsHidden && (!Settings.HideInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                if (!session.IsHidden && (!Settings.HideInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive || GetSessionIsSelected(session) || session.Equals(CurrentSession)))
                     return false;
             }
             return true;

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -24,7 +24,6 @@ namespace VolumeControl.CoreAudio
             AudioSessionManager = audioSessionManager;
 
             CurrentIndex = -1;
-            ActiveSession = null;
             _selectedSessions = new();
             _selectionStates = new();
             // populate the lists:
@@ -166,22 +165,6 @@ namespace VolumeControl.CoreAudio
                 NotifyCurrentSessionChanged(value);
             }
         }
-        /// <summary>
-        /// Gets or sets the active session temporarily for the notification.
-        /// </summary>
-        public AudioSession? ActiveSession
-        {
-            get => _activeSession;
-            set
-            {
-                //if (value != null && value.IsHidden)
-                //    return;
-                _activeSession = value;
-                NotifyPropertyChanged();
-                NotifyActiveSessionChanged(value);
-            }
-        }
-        private AudioSession? _activeSession;
         /// <inheritdoc/>
         public bool LockSelection
         {
@@ -233,7 +216,10 @@ namespace VolumeControl.CoreAudio
         /// Occurs when the ActiveSession is changed for any reason.
         /// </summary>
         public event EventHandler<AudioSession?>? ActiveSessionChanged;
-        private void NotifyActiveSessionChanged(AudioSession? audioSession) => ActiveSessionChanged?.Invoke(this, audioSession);
+        /// <summary>
+        /// Occurs when the ActiveSession is changed for any reason.
+        /// </summary>
+        public void NotifyActiveSessionChanged(AudioSession? audioSession) => ActiveSessionChanged?.Invoke(this, audioSession);
         /// <summary>
         /// Occurs prior to a new session being added, allowing handlers to determine if it should be selected by default.
         /// </summary>
@@ -293,8 +279,6 @@ namespace VolumeControl.CoreAudio
         }
         private void RemoveSession(AudioSession session)
         {
-            if (session.Equals(_activeSession))
-                ActiveSession = null;
             var index = Sessions.IndexOf(session); //< we can get the index here because the session hasn't been removed yet
             if (index == -1)
                 return;
@@ -378,18 +362,6 @@ namespace VolumeControl.CoreAudio
             }
         }
         #endregion Get/Set SessionIsSelected
-
-        #region GetSessionIsActive
-        /// <summary>
-        /// Gets whether the specified <paramref name="audioSession"/> is active or not, i.e. currently controlled by Active Application hotkeys.
-        /// </summary>
-        /// <param name="audioSession">An <see cref="AudioSession"/> instance.</param>
-        /// <returns><see langword="true"/> when the <paramref name="audioSession"/> is active; otherwise <see langword="false"/>.</returns>
-        public bool GetSessionIsActive(AudioSession audioSession)
-        {
-            return audioSession.Equals(ActiveSession);
-        }
-        #endregion GetSessionIsActive
 
         #region SetAllSessionSelectionStates
         /// <summary>

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -317,6 +317,7 @@ namespace VolumeControl.CoreAudio
         /// <exception cref="ArgumentException">The specified <paramref name="audioSession"/> does not exist in the <see cref="AudioSessionManager"/>.</exception>
         public void SetSessionIsSelected(AudioSession audioSession, bool isSelected)
         {
+            audioSession.IsSelected = isSelected;
             var index = Sessions.IndexOf(audioSession);
             if (index == -1)
                 throw new ArgumentException($"The specified {nameof(AudioSession)} instance was not found in the {nameof(AudioSessionManager)}'s {nameof(Sessions)} list!", nameof(audioSession));
@@ -526,7 +527,7 @@ namespace VolumeControl.CoreAudio
         {
             foreach (var session in Sessions)
             {
-                if (!session.IsHidden && (!Settings.HideInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive || GetSessionIsSelected(session) || session.Equals(CurrentSession)))
+                if (!session.IsHidden && (!Settings.HideInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive || session.IsSelected || session.Equals(CurrentSession)))
                     return false;
             }
             return true;

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -32,6 +32,7 @@ namespace VolumeControl.CoreAudio
 
             AudioSessionManager.AddedSessionToList += this.AudioSessionManager_SessionAddedToList;
             AudioSessionManager.RemovingSessionFromList += this.AudioSessionManager_RemovingSessionFromList;
+            AudioSessionManager.AddedSessionToHiddenList += this.AudioSessionManager_SessionAddedToList;
             AudioSessionManager.RemovingSessionFromHiddenList += this.AudioSessionManager_RemovingSessionFromList;
         }
         #endregion Constructor
@@ -512,26 +513,14 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            if (Settings.HideInactiveSessions)
+            int oldIndex = CurrentIndex;
+            if (oldIndex == -1)
+                oldIndex = 0;
+            do
             {
-                int oldIndex = CurrentIndex;
-                if (oldIndex == -1)
-                    oldIndex = 0;
-                do
-                {
-                    CurrentIndex = (CurrentIndex + 1) % SelectionStates.Count;
-                }
-                while (Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex);
+                CurrentIndex = (CurrentIndex + 1) % SelectionStates.Count;
             }
-            else
-            {
-                if (CurrentIndex < SelectionStates.Count - 1)
-                    ++CurrentIndex;
-                else
-                { // loopback:
-                    CurrentIndex = 0;
-                }
-            }
+            while (Sessions[CurrentIndex].IsHidden || (Settings.HideInactiveSessions && Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex));
         }
         /// <summary>
         /// Decrements the CurrentIndex by 1, looping back around to the length of the Sessions list when it goes past 0.
@@ -543,26 +532,14 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            if (Settings.HideInactiveSessions)
+            int oldIndex = CurrentIndex;
+            if (oldIndex == -1)
+                oldIndex = 0;
+            do
             {
-                int oldIndex = CurrentIndex;
-                if (oldIndex == -1)
-                    oldIndex = 0;
-                do
-                {
-                    CurrentIndex = (SelectionStates.Count + CurrentIndex - 1) % SelectionStates.Count;
-                }
-                while (Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex);
+                CurrentIndex = (SelectionStates.Count + CurrentIndex - 1) % SelectionStates.Count;
             }
-            else
-            {
-                if (CurrentIndex > 0)
-                    --CurrentIndex;
-                else
-                { // loopback:
-                    CurrentIndex = SelectionStates.Count - 1;
-                }
-            }
+            while (Sessions[CurrentIndex].IsHidden || (Settings.HideInactiveSessions && Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex));
         }
         /// <summary>
         /// Sets the CurrentIndex to 0.

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -517,6 +517,22 @@ namespace VolumeControl.CoreAudio
         }
         #endregion Increment/Decrement/Unset CurrentIndex
 
+        #region Notifications
+        /// <summary>
+        /// Gets whether the session notification would be empty after applying all filters.
+        /// </summary>
+        /// <returns><see langword="true"/> when the session notification would be empty; otherwise <see langword="false"/>.</returns>
+        public bool NotificationIsEmpty()
+        {
+            foreach (var session in Sessions)
+            {
+                if (!session.IsHidden && (!Settings.HideInactiveSessions || session.State == AudioSessionState.AudioSessionStateActive))
+                    return false;
+            }
+            return true;
+        }
+        #endregion Notifications
+
         #endregion Methods
 
         #region EventHandlers

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -31,8 +31,6 @@ namespace VolumeControl.CoreAudio
 
             AudioSessionManager.AddedSessionToList += this.AudioSessionManager_SessionAddedToList;
             AudioSessionManager.RemovingSessionFromList += this.AudioSessionManager_RemovingSessionFromList;
-            AudioSessionManager.AddedSessionToHiddenList += this.AudioSessionManager_SessionAddedToList;
-            AudioSessionManager.RemovingSessionFromHiddenList += this.AudioSessionManager_RemovingSessionFromList;
         }
         #endregion Constructor
 

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -483,14 +483,10 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            int oldIndex = CurrentIndex;
-            if (oldIndex == -1)
-                oldIndex = 0;
-            do
-            {
-                CurrentIndex = (CurrentIndex + 1) % SelectionStates.Count;
-            }
-            while (Sessions[CurrentIndex].IsHidden || (Settings.HideInactiveSessions && Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex));
+            int nextIndex = Sessions.Select((session, index) => new { Session = session, Index = index }).Where(o => o.Index > CurrentIndex && !o.Session.IsHidden && (!Settings.HideInactiveSessions || o.Session.State == AudioSessionState.AudioSessionStateActive)).Select(o => o.Index).FirstOrDefault<int>(CurrentIndex);
+            if (nextIndex == CurrentIndex)
+                nextIndex = Sessions.Select((session, index) => new { Session = session, Index = index }).Where(o => !o.Session.IsHidden && (!Settings.HideInactiveSessions || o.Session.State == AudioSessionState.AudioSessionStateActive)).Select(o => o.Index).FirstOrDefault<int>(CurrentIndex);
+            CurrentIndex = nextIndex;
         }
         /// <summary>
         /// Decrements the CurrentIndex by 1, looping back around to the length of the Sessions list when it goes past 0.
@@ -502,14 +498,10 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            int oldIndex = CurrentIndex;
-            if (oldIndex == -1)
-                oldIndex = 0;
-            do
-            {
-                CurrentIndex = (SelectionStates.Count + CurrentIndex - 1) % SelectionStates.Count;
-            }
-            while (Sessions[CurrentIndex].IsHidden || (Settings.HideInactiveSessions && Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex));
+            int nextIndex = Sessions.Select((session, index) => new { Session = session, Index = index }).Where(o => o.Index < CurrentIndex && !o.Session.IsHidden && (!Settings.HideInactiveSessions || o.Session.State == AudioSessionState.AudioSessionStateActive)).Select(o => o.Index).LastOrDefault<int>(CurrentIndex);
+            if (nextIndex == CurrentIndex)
+                nextIndex = Sessions.Select((session, index) => new { Session = session, Index = index }).Where(o => !o.Session.IsHidden && (!Settings.HideInactiveSessions || o.Session.State == AudioSessionState.AudioSessionStateActive)).Select(o => o.Index).LastOrDefault<int>(CurrentIndex);
+            CurrentIndex = nextIndex;
         }
         /// <summary>
         /// Sets the CurrentIndex to 0.

--- a/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
+++ b/VolumeControl.CoreAudio/AudioSessionMultiSelector.cs
@@ -4,6 +4,7 @@ using VolumeControl.CoreAudio.Events;
 using VolumeControl.CoreAudio.Interfaces;
 using VolumeControl.Log;
 using VolumeControl.TypeExtensions;
+using CoreAudio;
 
 namespace VolumeControl.CoreAudio
 {
@@ -470,12 +471,12 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            if (CurrentIndex < SelectionStates.Count - 1)
-                ++CurrentIndex;
-            else
-            { // loopback:
-                CurrentIndex = 0;
+            int oldIndex = CurrentIndex;
+            do
+            {
+                CurrentIndex = (CurrentIndex + 1) % SelectionStates.Count;
             }
+            while (Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex);
         }
         /// <summary>
         /// Decrements the CurrentIndex by 1, looping back around to the length of the Sessions list when it goes past 0.
@@ -487,12 +488,12 @@ namespace VolumeControl.CoreAudio
         {
             if (LockCurrentIndex) return;
 
-            if (CurrentIndex > 0)
-                --CurrentIndex;
-            else
-            { // loopback:
-                CurrentIndex = SelectionStates.Count - 1;
+            int oldIndex = CurrentIndex;
+            do
+            {
+                CurrentIndex = (SelectionStates.Count + CurrentIndex - 1) % SelectionStates.Count;
             }
+            while (Sessions[CurrentIndex].State != AudioSessionState.AudioSessionStateActive && CurrentIndex != oldIndex);
         }
         /// <summary>
         /// Sets the CurrentIndex to 0.

--- a/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
+++ b/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
@@ -173,6 +173,13 @@ namespace VolumeControl.HotkeyActions
                 VCAPI.ShowSessionListNotification(sessions);
             }
         }
+        [HotkeyAction(Description = "Shows the active application notification if there are sessions to show.")]
+        public void Show(object? sender, HotkeyPressedEventArgs e)
+        {
+            var sessions = GetActiveSessions();
+            if (sessions.Count > 0)
+                VCAPI.ShowSessionListNotification(sessions);
+        }
         #endregion Methods
     }
 }

--- a/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
+++ b/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
@@ -48,10 +48,10 @@ namespace VolumeControl.HotkeyActions
                 return null;
 
 
-            if (VCAPI.AudioSessionManager.FindSessionWithPID((uint)pid, includeHiddenSessions: true) is AudioSession session)
+            if ((VCAPI.AudioSessionManager.FindSessionWithPID((uint)pid, includeHiddenSessions: true, includeInactiveSessions: false) ?? VCAPI.AudioSessionManager.FindSessionWithPID((uint)pid, includeHiddenSessions: true, includeInactiveSessions: true)) is AudioSession session)
                 return session; //< found with process ID
 
-            return VCAPI.AudioSessionManager.FindSessionWithProcessName(System.Diagnostics.Process.GetProcessById(pid).ProcessName, includeHiddenSessions: true);
+            return VCAPI.AudioSessionManager.FindSessionWithProcessName(System.Diagnostics.Process.GetProcessById(pid).ProcessName, includeHiddenSessions: true, includeInactiveSessions: false) ?? VCAPI.AudioSessionManager.FindSessionWithProcessName(System.Diagnostics.Process.GetProcessById(pid).ProcessName, includeHiddenSessions: true, includeInactiveSessions: true);
         }
         #endregion Functions
 

--- a/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
+++ b/VolumeControl.HotkeyActions/ActiveApplicationActions.cs
@@ -69,8 +69,8 @@ namespace VolumeControl.HotkeyActions
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))
                 {
                     VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(session);
-                    VCAPI.ShowSessionListNotification();
                 }
+                VCAPI.ShowSessionListNotification(session);
             }
         }
         [HotkeyAction(Description = "Decreases the volume of the current foreground application.")]
@@ -86,8 +86,8 @@ namespace VolumeControl.HotkeyActions
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))
                 {
                     VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(session);
-                    VCAPI.ShowSessionListNotification();
                 }
+                VCAPI.ShowSessionListNotification(session);
             }
         }
         [HotkeyAction(Description = "Mutes the current foreground application.")]
@@ -100,8 +100,8 @@ namespace VolumeControl.HotkeyActions
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))
                 {
                     VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(session);
-                    VCAPI.ShowSessionListNotification();
                 }
+                VCAPI.ShowSessionListNotification(session);
             }
         }
         [HotkeyAction(Description = "Unmutes the current foreground application.")]
@@ -114,8 +114,8 @@ namespace VolumeControl.HotkeyActions
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))
                 {
                     VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(session);
-                    VCAPI.ShowSessionListNotification();
                 }
+                VCAPI.ShowSessionListNotification(session);
             }
         }
         [HotkeyAction(Description = "(Un)Mutes the current foreground application.")]
@@ -128,8 +128,8 @@ namespace VolumeControl.HotkeyActions
                 if (e.GetValue<bool>(Setting_SelectTarget_Name))
                 {
                     VCAPI.AudioSessionMultiSelector.SetSelectedSessionsOrCurrentSession(session);
-                    VCAPI.ShowSessionListNotification();
                 }
+                VCAPI.ShowSessionListNotification(session);
             }
         }
         #endregion Methods

--- a/VolumeControl.HotkeyActions/AudioDeviceActions.cs
+++ b/VolumeControl.HotkeyActions/AudioDeviceActions.cs
@@ -146,6 +146,11 @@ namespace VolumeControl.HotkeyActions
 
             VCAPI.ShowDeviceListNotification();
         }
+        [HotkeyAction(Description = "Shows the device notification.")]
+        public void Show(object? sender, HotkeyPressedEventArgs e)
+        {
+            VCAPI.ShowDeviceListNotification();
+        }
         #endregion Action Methods
     }
 }

--- a/VolumeControl.HotkeyActions/AudioSessionActions.cs
+++ b/VolumeControl.HotkeyActions/AudioSessionActions.cs
@@ -61,7 +61,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
                     {
                         session.IncreaseVolume(volumeStep);
                         sessions.Add(session);
@@ -107,7 +107,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
                     {
                         session.DecreaseVolume(volumeStep);
                         sessions.Add(session);
@@ -212,7 +212,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
                     {
                         session.SetMute(true);
                         sessions.Add(session);
@@ -253,7 +253,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
                     {
                         session.SetMute(false);
                         sessions.Add(session);
@@ -294,7 +294,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
                     {
                         session.ToggleMute();
                         sessions.Add(session);

--- a/VolumeControl.HotkeyActions/AudioSessionActions.cs
+++ b/VolumeControl.HotkeyActions/AudioSessionActions.cs
@@ -61,7 +61,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    if (VCAPI.AudioSessionManager.FindSessionWithName(specifier.Targets[i]) is AudioSession session)
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
                     {
                         session.IncreaseVolume(volumeStep);
                         sessions.Add(session);
@@ -107,7 +107,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    if (VCAPI.AudioSessionManager.FindSessionWithName(specifier.Targets[i]) is AudioSession session)
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
                     {
                         session.DecreaseVolume(volumeStep);
                         sessions.Add(session);
@@ -212,7 +212,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    if (VCAPI.AudioSessionManager.FindSessionWithName(specifier.Targets[i]) is AudioSession session)
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
                     {
                         session.SetMute(true);
                         sessions.Add(session);
@@ -253,7 +253,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    if (VCAPI.AudioSessionManager.FindSessionWithName(specifier.Targets[i]) is AudioSession session)
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
                     {
                         session.SetMute(false);
                         sessions.Add(session);
@@ -294,7 +294,7 @@ namespace VolumeControl.HotkeyActions
                 List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
-                    if (VCAPI.AudioSessionManager.FindSessionWithName(specifier.Targets[i]) is AudioSession session)
+                    foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true))
                     {
                         session.ToggleMute();
                         sessions.Add(session);

--- a/VolumeControl.HotkeyActions/AudioSessionActions.cs
+++ b/VolumeControl.HotkeyActions/AudioSessionActions.cs
@@ -377,6 +377,11 @@ namespace VolumeControl.HotkeyActions
 
             VCAPI.ShowSessionListNotification();
         }
+        [HotkeyAction(Description = "Shows the session notification.")]
+        public void Show(object? sender, HotkeyPressedEventArgs e)
+        {
+            VCAPI.ShowSessionListNotification();
+        }
         #endregion Action Methods
     }
 }

--- a/VolumeControl.HotkeyActions/AudioSessionActions.cs
+++ b/VolumeControl.HotkeyActions/AudioSessionActions.cs
@@ -52,13 +52,13 @@ namespace VolumeControl.HotkeyActions
         public void VolumeUp(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
 
             // get the volume step size
             int volumeStep = e.GetValueOrDefault(Setting_VolumeStep_Name, VCAPI.Settings.VolumeStepSize);
 
             if (e.GetValue<ActionTargetSpecifier>(Setting_TargetOverride_Name) is ActionTargetSpecifier specifier && specifier.Targets.Count > 0)
             { // operate on target overrides:
-                List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
                     foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
@@ -89,7 +89,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Decreases the volume of the session(s).")]
         [HotkeyActionSetting(Setting_TargetOverride_Name, typeof(ActionTargetSpecifier), "ActionTargetSpecifierDataTemplate", Description = Setting_TargetOverride_Description)]
@@ -98,13 +98,13 @@ namespace VolumeControl.HotkeyActions
         public void VolumeDown(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
 
             // get the volume step size
             int volumeStep = e.GetValueOrDefault(Setting_VolumeStep_Name, VCAPI.Settings.VolumeStepSize);
 
             if (e.GetValue<ActionTargetSpecifier>(Setting_TargetOverride_Name) is ActionTargetSpecifier specifier && specifier.Targets.Count > 0)
             { // operate on target overrides:
-                List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
                     foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
@@ -135,7 +135,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Sets the volume and/or mute state of the session(s).")]
         [HotkeyActionSetting(Setting_TargetOverride_Name, typeof(ActionTargetSpecifier), "ActionTargetSpecifierDataTemplate", Description = Setting_TargetOverride_Description)]
@@ -146,6 +146,7 @@ namespace VolumeControl.HotkeyActions
         public void SetVolume(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
 
             var (setVolumeLevel, volumeLevel) = e.GetSetting<int>(Setting_VolumeLevel_Name);
             var (setMuteState, muteState) = e.GetSetting<bool>(Setting_MuteState_Name);
@@ -156,7 +157,6 @@ namespace VolumeControl.HotkeyActions
             if (targetAllSessions || targetSpecifier.Targets.Count > 0)
             { // operate on target overrides:
                 var selectTargets = e.GetValue<bool>(Setting_SelectTarget_Name);
-                List<AudioSession>? sessions = selectTargets ? new() : null;
 
                 foreach (var session in VCAPI.AudioSessionManager.Sessions)
                 {
@@ -166,7 +166,7 @@ namespace VolumeControl.HotkeyActions
                             session.Volume = volumeLevel;
                         if (setMuteState)
                             session.Mute = muteState;
-                        sessions?.Add(session);
+                        sessions.Add(session);
                         showNotification = true;
                     }
                 }
@@ -199,7 +199,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Mutes the session(s).")]
         [HotkeyActionSetting(Setting_TargetOverride_Name, typeof(ActionTargetSpecifier), "ActionTargetSpecifierDataTemplate", Description = Setting_TargetOverride_Description)]
@@ -207,9 +207,10 @@ namespace VolumeControl.HotkeyActions
         public void Mute(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
+
             if (e.GetValue<ActionTargetSpecifier>(Setting_TargetOverride_Name) is ActionTargetSpecifier specifier && specifier.Targets.Count > 0)
             { // operate on target overrides:
-                List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
                     foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
@@ -240,7 +241,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Unmutes the session(s).")]
         [HotkeyActionSetting(Setting_TargetOverride_Name, typeof(ActionTargetSpecifier), "ActionTargetSpecifierDataTemplate", Description = Setting_TargetOverride_Description)]
@@ -248,9 +249,10 @@ namespace VolumeControl.HotkeyActions
         public void Unmute(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
+
             if (e.GetValue<ActionTargetSpecifier>(Setting_TargetOverride_Name) is ActionTargetSpecifier specifier && specifier.Targets.Count > 0)
             { // operate on target overrides:
-                List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
                     foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
@@ -281,7 +283,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Toggles the mute state of the session(s).")]
         [HotkeyActionSetting(Setting_TargetOverride_Name, typeof(ActionTargetSpecifier), "ActionTargetSpecifierDataTemplate", Description = Setting_TargetOverride_Description)]
@@ -289,9 +291,10 @@ namespace VolumeControl.HotkeyActions
         public void ToggleMute(object? sender, HotkeyPressedEventArgs e)
         {
             bool showNotification = false;
+            List<AudioSession> sessions = new();
+
             if (e.GetValue<ActionTargetSpecifier>(Setting_TargetOverride_Name) is ActionTargetSpecifier specifier && specifier.Targets.Count > 0)
             { // operate on target overrides:
-                List<AudioSession> sessions = new();
                 for (int i = 0, max = specifier.Targets.Count; i < max; ++i)
                 {
                     foreach (var session in VCAPI.AudioSessionManager.FindSessionsWithName(specifier.Targets[i], includeHiddenSessions: true, includeInactiveSessions: !VCAPI.Settings.HideInactiveSessions))
@@ -322,7 +325,7 @@ namespace VolumeControl.HotkeyActions
                 return; //< don't show notifs if they're disabled on volume change
 
             if (showNotification)
-                VCAPI.ShowSessionListNotification();
+                VCAPI.ShowSessionListNotification(sessions);
         }
         [HotkeyAction(Description = "Changes the current session to the next session in the list.")]
         public void SelectNext(object? sender, HotkeyPressedEventArgs e)

--- a/VolumeControl.SDK/VCAPI.cs
+++ b/VolumeControl.SDK/VCAPI.cs
@@ -82,12 +82,41 @@ namespace VolumeControl.SDK
         /// <summary>
         /// Display the SessionListNotification window.
         /// </summary>
-        public void ShowSessionListNotification(AudioSession? activeSession = null)
+        public void ShowSessionListNotification()
         {
             // don't trigger notification events if notifs are disabled-
             if (!Settings.SessionListNotificationConfig.Enabled) return;
 
-            AudioSessionMultiSelector.ActiveSession = activeSession;
+            AudioSessionMultiSelector.NotifyActiveSessionChanged(null);
+            VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);
+        }
+        /// <summary>
+        /// Display the SessionListNotification window.
+        /// </summary>
+        public void ShowSessionListNotification(List<AudioSession> activeSessions)
+        {
+            // don't trigger notification events if notifs are disabled-
+            if (!Settings.SessionListNotificationConfig.Enabled) return;
+
+
+            if (activeSessions != null)
+            {
+                foreach (var session in activeSessions)
+                {
+                    AudioSessionMultiSelector.NotifyActiveSessionChanged(session);
+                }
+            }
+            VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);
+        }
+        /// <summary>
+        /// Display the SessionListNotification window.
+        /// </summary>
+        public void ShowSessionListNotification(AudioSession activeSession)
+        {
+            // don't trigger notification events if notifs are disabled-
+            if (!Settings.SessionListNotificationConfig.Enabled) return;
+
+            AudioSessionMultiSelector.NotifyActiveSessionChanged(activeSession);
             VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);
         }
         /// <summary>

--- a/VolumeControl.SDK/VCAPI.cs
+++ b/VolumeControl.SDK/VCAPI.cs
@@ -86,6 +86,7 @@ namespace VolumeControl.SDK
         {
             // don't trigger notification events if notifs are disabled-
             if (!Settings.SessionListNotificationConfig.Enabled) return;
+            if (AudioSessionMultiSelector.NotificationIsEmpty()) return;
 
             AudioSessionMultiSelector.NotifyActiveSessionChanged(null);
             VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);

--- a/VolumeControl.SDK/VCAPI.cs
+++ b/VolumeControl.SDK/VCAPI.cs
@@ -82,11 +82,12 @@ namespace VolumeControl.SDK
         /// <summary>
         /// Display the SessionListNotification window.
         /// </summary>
-        public void ShowSessionListNotification()
+        public void ShowSessionListNotification(AudioSession? activeSession = null)
         {
             // don't trigger notification events if notifs are disabled-
             if (!Settings.SessionListNotificationConfig.Enabled) return;
 
+            AudioSessionMultiSelector.ActiveSession = activeSession;
             VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);
         }
         /// <summary>

--- a/VolumeControl.SDK/VCAPI.cs
+++ b/VolumeControl.SDK/VCAPI.cs
@@ -98,7 +98,7 @@ namespace VolumeControl.SDK
             // don't trigger notification events if notifs are disabled-
             if (!Settings.SessionListNotificationConfig.Enabled) return;
 
-
+            AudioSessionMultiSelector.NotifyActiveSessionChanged(null);
             if (activeSessions != null)
             {
                 foreach (var session in activeSessions)
@@ -116,6 +116,7 @@ namespace VolumeControl.SDK
             // don't trigger notification events if notifs are disabled-
             if (!Settings.SessionListNotificationConfig.Enabled) return;
 
+            AudioSessionMultiSelector.NotifyActiveSessionChanged(null);
             AudioSessionMultiSelector.NotifyActiveSessionChanged(activeSession);
             VCEvents.NotifyShowSessionListNotification(this, EventArgs.Empty);
         }

--- a/VolumeControl/Helpers/VCSettings.cs
+++ b/VolumeControl/Helpers/VCSettings.cs
@@ -175,6 +175,12 @@ namespace VolumeControl.Helpers
             get => Settings.LockTargetSession;
             set => Settings.LockTargetSession = value;
         }
+        /// <inheritdoc cref="Config.HideInactiveSessions"/>
+        public bool HideInactiveSessions
+        {
+            get => Settings.HideInactiveSessions;
+            set => Settings.HideInactiveSessions = value;
+        }
         /// <inheritdoc cref="Config.LockTargetDevice"/>
         public bool LockTargetDevice
         {

--- a/VolumeControl/Localization/en.loc.json
+++ b/VolumeControl/Localization/en.loc.json
@@ -127,8 +127,8 @@
               "Tooltip": {}
             },
             "HideInactiveSessions": {
-              "Content": "Hide Inactive Sessions",
-              "Tooltip": "Toggle hiding inactive sessions in the notification window and also ignore inactive sessions with next/previous hotkeys."
+              "Content": "Ignore Inactive Sessions",
+              "Tooltip": "Toggle hiding inactive sessions in the notification window and ignore inactive sessions in hotkey actions."
             },
           },
           "DeviceGrid": {

--- a/VolumeControl/Localization/en.loc.json
+++ b/VolumeControl/Localization/en.loc.json
@@ -122,7 +122,11 @@
             "HiddenSessions": {
               "Content": "Hidden Sessions",
               "Tooltip": {}
-            }
+            },
+            "HideInactiveSessions": {
+              "Content": "Hide Inactive Sessions",
+              "Tooltip": "Toggle hiding inactive sessions in the notification window and also ignore inactive sessions with next/previous hotkeys."
+            },
           },
           "DeviceGrid": {
             "Enabled": {

--- a/VolumeControl/Localization/en.loc.json
+++ b/VolumeControl/Localization/en.loc.json
@@ -38,6 +38,9 @@
           },
           "Select": {
             "Button": "Select"
+          },
+          "Device": {
+            "Header": "Device"
           }
         }
       },

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -1437,11 +1437,11 @@
                                                         ToolTip="{Tr 'VolumeControl.MainWindow.Settings.Audio.AdditionalSettings.EnableDeviceControl.Tooltip',
                                                                      DefaultText='Toggle the visibility of volume &amp; mute controls in the Audio Devices section.'}" />
                                                     <CheckBox
-                                                        Content="{Tr 'VolumeControl.ListNotification.Options.HideInactiveSessions.Tooltip',
+                                                        Content="{Tr 'VolumeControl.MainWindow.Settings.Audio.AdditionalSettings.HideInactiveSessions.Content',
                                                                     DefaultText='Hide Inactive Sessions'}"
                                                         IsChecked="{Binding HideInactiveSessions, Source={StaticResource Settings}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                         Style="{StaticResource ApplicationSettingsCheckboxStyle}"
-                                                        ToolTip="{Tr 'VolumeControl.ListNotification.Options.HideInactiveSessions.Tooltip',
+                                                        ToolTip="{Tr 'VolumeControl.MainWindow.Settings.Audio.AdditionalSettings.HideInactiveSessions.Tooltip',
                                                                     DefaultText=' '}" />
                                                 </StackPanel>
 

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -893,8 +893,7 @@
                                                                     <Style TargetType="TextBlock">
                                                                         <Style.Triggers>
                                                                             <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
-                                                                                <Setter Property="Foreground"
-                                                                                        Value="Pink" />
+                                                                                <Setter Property="Foreground" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
                                                                             </DataTrigger>
                                                                         </Style.Triggers>
                                                                     </Style>
@@ -1437,6 +1436,13 @@
                                                         Style="{StaticResource ApplicationSettingsCheckboxStyle}"
                                                         ToolTip="{Tr 'VolumeControl.MainWindow.Settings.Audio.AdditionalSettings.EnableDeviceControl.Tooltip',
                                                                      DefaultText='Toggle the visibility of volume &amp; mute controls in the Audio Devices section.'}" />
+                                                    <CheckBox
+                                                        Content="{Tr 'VolumeControl.ListNotification.Options.HideInactiveSessions.Tooltip',
+                                                                    DefaultText='Hide Inactive Sessions'}"
+                                                        IsChecked="{Binding HideInactiveSessions, Source={StaticResource Settings}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                        Style="{StaticResource ApplicationSettingsCheckboxStyle}"
+                                                        ToolTip="{Tr 'VolumeControl.ListNotification.Options.HideInactiveSessions.Tooltip',
+                                                                    DefaultText=' '}" />
                                                 </StackPanel>
 
                                                 <!--  Hidden Sessions  -->

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -919,7 +919,7 @@
                                                             HorizontalAlignment="Stretch"
                                                             VerticalAlignment="Center"
                                                             Background="#0000"
-                                                            Text="{Binding AudioSession.DeviceName, Mode=OneWay, UpdateSourceTrigger=LostFocus}" />
+                                                            Text="{Binding AudioSession.DeviceFlowName, Mode=OneWay, UpdateSourceTrigger=LostFocus}" />
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>
                                             </DataGridTemplateColumn>

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -888,7 +888,18 @@
                                                                 HorizontalAlignment="Stretch"
                                                                 VerticalAlignment="Center"
                                                                 Background="#0000"
-                                                                Text="{Binding AudioSession.Name, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" />
+                                                                Text="{Binding AudioSession.Name, Mode=TwoWay, UpdateSourceTrigger=LostFocus}">
+                                                                <TextBlock.Style>
+                                                                    <Style TargetType="TextBlock">
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
+                                                                                <Setter Property="Foreground"
+                                                                                        Value="Pink" />
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </TextBlock.Style>
+                                                            </TextBlock>
                                                         </Grid>
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -903,6 +903,26 @@
                                                     </DataTemplate>
                                                 </DataGridTemplateColumn.CellTemplate>
                                             </DataGridTemplateColumn>
+                                            <!--  Dev  -->
+                                            <DataGridTemplateColumn
+                                                x:Name="dgSessionDeviceColumn"
+                                                Width="Auto"
+                                                MinWidth="80"
+                                                Header="{Tr 'VolumeControl.MainWindow.Mixer.MixerGrid.Device.Header',
+                                                            DefaultText='Device'}"
+                                                IsReadOnly="True">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate DataType="{x:Type vm:AudioSessionVM}">
+                                                        <TextBlock
+                                                            Margin="6,0"
+                                                            Grid.Column="1"
+                                                            HorizontalAlignment="Stretch"
+                                                            VerticalAlignment="Center"
+                                                            Background="#0000"
+                                                            Text="{Binding AudioSession.DeviceName, Mode=OneWay, UpdateSourceTrigger=LostFocus}" />
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
                                             <!--  Mute  -->
                                             <DataGridTemplateColumn Width="40" Header="{Tr 'VolumeControl.MainWindow.Mixer.MixerGrid.Mute.Header', DefaultText='Mute'}">
                                                 <DataGridTemplateColumn.CellTemplate>

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -844,6 +844,9 @@
                                                             <Setter Property="Background" Value="{StaticResource GridSecondaryRowAltBrush}" />
                                                         </MultiDataTrigger.Setters>
                                                     </MultiDataTrigger>
+                                                    <DataTrigger Binding="{Binding AudioSession.IsHidden, Mode=OneWay}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
                                         </DataGrid.RowStyle>

--- a/VolumeControl/Mixer.xaml
+++ b/VolumeControl/Mixer.xaml
@@ -227,6 +227,7 @@
                                 <RowDefinition />
                                 <RowDefinition />
                                 <RowDefinition />
+                                <RowDefinition />
                             </Grid.RowDefinitions>
 
                             <!--  Row 0 ; Col 0-1  -->
@@ -281,17 +282,32 @@
                                 Grid.Row="1"
                                 Grid.Column="3"
                                 Fill="{Binding UnlockedAccentBrush}" />
+                            <!--  Row 1 ; Col 2-3  -->
+                            <TextBox
+                                Grid.Row="2"
+                                Grid.Column="0"
+                                Text="{Binding ConfigSection.ActiveColor}"
+                                ToolTip="{Tr 'VolumeControl.MainWindow.Settings.Notifications.ColorPicker.ActiveAccent.Tooltip',
+                                             DefaultText='Sets the accent color of the notification window when selection is active.'}">
+                                <i:Interaction.Behaviors>
+                                    <wpfBehaviors:TextBoxEnterUpdatesTextSourceBehavior />
+                                </i:Interaction.Behaviors>
+                            </TextBox>
+                            <Ellipse
+                                Grid.Row="2"
+                                Grid.Column="1"
+                                Fill="{Binding ActiveAccentBrush}" />
 
                             <!--  Row 2 ; Col 0-3  -->
                             <TextBlock
-                                Grid.Row="2"
+                                Grid.Row="3"
                                 Grid.ColumnSpan="2"
                                 Margin="5,3"
                                 Style="{StaticResource TextBlockStyle}"
                                 Text="{Tr 'VolumeControl.MainWindow.Settings.Notifications.CornerRadius.Content',
                                           DefaultText='Corner Radius:'}" />
                             <TextBox
-                                Grid.Row="2"
+                                Grid.Row="3"
                                 Grid.Column="2"
                                 Grid.ColumnSpan="2"
                                 MaxLength="-1"

--- a/VolumeControl/Program.cs
+++ b/VolumeControl/Program.cs
@@ -141,7 +141,7 @@ namespace VolumeControl
             // show all log message types in debug mode
             FLog.Log.EventTypeFilter = EventType.DEBUG | EventType.INFO | EventType.WARN | EventType.ERROR | EventType.FATAL | EventType.TRACE;
             // open the log file for monitoring
-            ShellHelper.Start(new("notepad++.exe", $"-monitor \"{Settings.LogPath}\"") { UseShellExecute = true });
+            //no thanks ShellHelper.Start(new("notepad++.exe", $"-monitor \"{Settings.LogPath}\"") { UseShellExecute = true });
 #endif
 
             // write the config & log filepaths to the log

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -307,6 +307,10 @@
                                         <Setter Property="Visibility" Value="Collapsed" />
                                     </MultiDataTrigger.Setters>
                                 </MultiDataTrigger>
+                                <!--  Hide hidden sessions  -->
+                                <DataTrigger Binding="{Binding AudioSession.IsHidden, Mode=OneWay}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
                                 <!--  Selector (Multi-Selection Mode Only):  -->
                                 <MultiDataTrigger>
                                     <MultiDataTrigger.Conditions>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -143,13 +143,18 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
                         FontSize="13"
-                        Foreground="{Binding SessionConfigVM.ForegroundBrush, Source={StaticResource Settings}}"
                         Text="{Binding Name}">
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding AudioSession.DataFlow}" Value="Capture">
                                         <Setter Property="FontStyle" Value="Oblique" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
+                                        <Setter Property="Foreground" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="1">
+                                        <Setter Property="Foreground" Value="{Binding SessionConfigVM.ForegroundBrush, Source={StaticResource Settings}}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -180,13 +185,18 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
                         FontSize="13"
-                        Foreground="{Binding SessionConfigVM.ForegroundBrush, Source={StaticResource Settings}}"
                         Text="{Binding Name}">
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding AudioSession.DataFlow}" Value="Capture">
                                         <Setter Property="FontStyle" Value="Oblique" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
+                                        <Setter Property="Foreground" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="1">
+                                        <Setter Property="Foreground" Value="{Binding SessionConfigVM.ForegroundBrush, Source={StaticResource Settings}}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -278,10 +288,16 @@
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
                         <Style.Triggers>
-                            <!--  Hide inactive sessions TODO: probably needs an option  -->
-                            <DataTrigger Binding="{Binding AudioSession.State}" Value="0">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
+                            <!--  Hide inactive sessions  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
+                                    <Condition Binding="{Binding AudioSession.State}" Value="0" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
                             <!--  Selector (Multi-Selection Mode Only):  -->
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -278,6 +278,10 @@
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
                         <Style.Triggers>
+                            <!--  Hide inactive sessions TODO: probably needs an option  -->
+                            <DataTrigger Binding="{Binding AudioSession.State}" Value="0">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
                             <!--  Selector (Multi-Selection Mode Only):  -->
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -54,6 +54,16 @@
                 <conv:BooleanInverter />
             </conv:ConverterChain>
             <conv:NullToBooleanConverter x:Key="NullableToBooleanConverter" />
+            <conv:ListHasItemsBooleanConverter x:Key="ListHasItemsBooleanConverter" />
+            <conv:ConverterChain x:Key="ListHasItemsVisibilityConverter">
+                <conv:ListHasItemsBooleanConverter />
+                <BooleanToVisibilityConverter />
+            </conv:ConverterChain>
+            <conv:ConverterChain x:Key="InvertedListHasItemsVisibilityConverter">
+                <conv:ListHasItemsBooleanConverter />
+                <conv:BooleanInverter />
+                <BooleanToVisibilityConverter />
+            </conv:ConverterChain>
 
             <!--  Styles  -->
             <Style BasedOn="{StaticResource TextBoxStyle}" TargetType="{x:Type TextBox}">
@@ -253,219 +263,260 @@
                     <DataTrigger Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False">
                         <Setter Property="BorderBrush" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
                     </DataTrigger>
-                    <DataTrigger Binding="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToBooleanConverter}}" Value="True">
+                    <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
                         <Setter Property="BorderBrush" Value="{Binding SessionConfigVM.ActiveAccentBrush, Source={StaticResource Settings}}" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
         </Border.Style>
         <Grid>
-            <Grid Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToVisibilityConverter}}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-                <!--  Row 0 (ListView)  -->
-                <ListView
-                    x:Name="ListView"
-                    Margin="6,6,6,8"
-                    Padding="1"
-                    Background="#0000"
-                    ItemTemplate="{StaticResource SessionDisplayAlwaysBoldWidthDataTemplate}"
-                    ItemsSource="{Binding AudioAPI.AllSessions, Source={StaticResource Settings}, Mode=OneWay}"
-                    PreviewMouseDown="ListView_PreviewMouseDown"
-                    SelectedIndex="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}"
-                    SelectionMode="Single">
-                    <i:Interaction.Behaviors>
-                        <wpfBehaviors:MouseWheelListViewBehavior />
-                    </i:Interaction.Behaviors>
-                    <ListView.Style>
-                        <Style TargetType="{x:Type ListView}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowFullList, Source={StaticResource Settings}}" Value="False">
+            <!--  Row 0 (ListView)  -->
+            <ListView
+                x:Name="ListView"
+                Margin="6,6,6,8"
+                Padding="1"
+                Background="#0000"
+                ItemTemplate="{StaticResource SessionDisplayAlwaysBoldWidthDataTemplate}"
+                PreviewMouseDown="ListView_PreviewMouseDown"
+                SelectedIndex="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}"
+                SelectionMode="Single">
+                <i:Interaction.Behaviors>
+                    <wpfBehaviors:MouseWheelListViewBehavior />
+                </i:Interaction.Behaviors>
+                <ListView.Style>
+                    <Style TargetType="{x:Type ListView}">
+                        <Setter Property="ItemsSource" Value="{Binding AudioAPI.AllSessions, Source={StaticResource Settings}, Mode=OneWay}" />
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="Background" Value="#0000" />
+                        <Setter Property="FocusVisualStyle" Value="{StaticResource CustomFocusVisualStyle}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowFullList, Source={StaticResource Settings}}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
+                                <Setter Property="ItemsSource" Value="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ListView.Style>
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="{x:Type ListViewItem}">
+                        <Style.Triggers>
+                            <!--  Hide inactive sessions, unless selected  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
+                                    <Condition Binding="{Binding AudioSession.State}" Value="0" />
+                                    <Condition Binding="{Binding IsSelected}" Value="False" />
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
+                                    <Condition Binding="{Binding AudioAPI.ActiveSessions.Count, Source={StaticResource Settings}}" Value="0" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
                                     <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                            <Setter Property="BorderThickness" Value="0" />
-                            <Setter Property="Background" Value="#0000" />
-                            <Setter Property="FocusVisualStyle" Value="{StaticResource CustomFocusVisualStyle}" />
-                        </Style>
-                    </ListView.Style>
-                    <ListView.ItemContainerStyle>
-                        <Style TargetType="{x:Type ListViewItem}">
-                            <Style.Triggers>
-                                <!--  Hide inactive sessions, unless selected  -->
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
-                                        <Condition Binding="{Binding AudioSession.State}" Value="0" />
-                                        <Condition Binding="{Binding IsSelected}" Value="False" />
-                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                                <!--  Hide hidden sessions  -->
-                                <DataTrigger Binding="{Binding AudioSession.IsHidden, Mode=OneWay}" Value="True">
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <!--  Hide hidden sessions, unless active  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding AudioSession.IsHidden, Mode=OneWay}" Value="True" />
+                                    <Condition Binding="{Binding AudioAPI.ActiveSessions.Count, Source={StaticResource Settings}}" Value="0" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
                                     <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                                <!--  Selector (Multi-Selection Mode Only):  -->
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="True" />
-                                        <!--  Binds to ListViewItem.IsSelected:  -->
-                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="BorderBrush" Value="{StaticResource TextBoxForeground}" />
-                                        <Setter Property="FontWeight" Value="Bold" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                                <!--  Selector (Single-Selection Mode Only):  -->
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
-                                        <!--  Binds to ListViewItem.IsSelected:  -->
-                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
-                                        <Setter Property="FontWeight" Value="Bold" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
-                                        <!--  Binds to ListViewItem.IsSelected:  -->
-                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
-                                        <Setter Property="FontWeight" Value="Bold" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <!--  Selector (Multi-Selection Mode Only):  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="True" />
+                                    <!--  Binds to ListViewItem.IsSelected:  -->
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="BorderBrush" Value="{StaticResource TextBoxForeground}" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <!--  Selector (Single-Selection Mode Only):  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
+                                    <!--  Binds to ListViewItem.IsSelected:  -->
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
+                                    <!--  Binds to ListViewItem.IsSelected:  -->
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
 
-                                <!--  Binds to AudioSessionVM.IsSelected:  -->
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding IsSelected}" Value="True" />
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding IsSelected}" Value="True" />
-                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                            </Style.Triggers>
-                            <Setter Property="BorderThickness" Value="1.5" />
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-                            <Setter Property="Margin" Value="0,1" />
-                            <Setter Property="Padding" Value="6,4" />
-                            <Setter Property="Template">
-                                <Setter.Value>
-                                    <ControlTemplate TargetType="{x:Type ListViewItem}">
-                                        <Border
-                                            Margin="{TemplateBinding Margin}"
-                                            Padding="{TemplateBinding Padding}"
-                                            Background="{TemplateBinding Background}"
-                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                            BorderThickness="{TemplateBinding BorderThickness}"
-                                            CornerRadius="{StaticResource RoundedControlCorner}"
-                                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}">
-                                            <ContentPresenter
-                                                Content="{TemplateBinding Content}"
-                                                ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
-                                        </Border>
-                                    </ControlTemplate>
-                                </Setter.Value>
-                            </Setter>
-                            <EventSetter Event="Selected" Handler="ListViewItem_Selected" />
-                        </Style>
-                    </ListView.ItemContainerStyle>
-                </ListView>
+                            <!--  Binds to AudioSessionVM.IsSelected:  -->
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding IsSelected}" Value="True" />
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding IsSelected}" Value="True" />
+                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                        <Setter Property="BorderThickness" Value="1.5" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Setter Property="Margin" Value="0,1" />
+                        <Setter Property="Padding" Value="6,4" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                    <Border
+                                        Margin="{TemplateBinding Margin}"
+                                        Padding="{TemplateBinding Padding}"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{StaticResource RoundedControlCorner}"
+                                        FocusVisualStyle="{TemplateBinding FocusVisualStyle}">
+                                        <ContentPresenter
+                                            Content="{TemplateBinding Content}"
+                                            ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <EventSetter Event="Selected" Handler="ListViewItem_Selected" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+            </ListView>
 
-                <!--  Row 1 (Controls)  -->
-                <Grid Grid.Row="1" Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToVisibilityConverter}}">
-                    <Grid.Style>
-                        <Style TargetType="{x:Type Grid}">
+            <!--  Row 1 (Controls)  -->
+            <Grid Grid.Row="1">
+                <Grid.Style>
+                    <Style TargetType="{x:Type Grid}">
+                        <Style.Triggers>
+                            <!--  Hide controls when viewmode doesn't include them  -->
+                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+
+                <ItemsControl
+                    x:Name="MultiSelectionControls"
+                    Margin="2"
+                    Visibility="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <ItemsControl.Style>
+                        <Style TargetType="{x:Type ItemsControl}">
                             <Style.Triggers>
-                                <!--  Hide controls when viewmode doesn't include them  -->
-                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
+                                <!--  Use display/control hybrid template when only selected sessions are visible  -->
                                 <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionFullDataTemplate}" />
+                                </DataTrigger>
+                                <!--  Override last and use display template when control bar isn't visible  -->
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
+                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
+                                    <Setter Property="ItemsSource" Value="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay}" />
                                 </DataTrigger>
                             </Style.Triggers>
+                            <Setter Property="ItemsSource" Value="{Binding AudioAPI.SelectedSessions, Source={StaticResource Settings}}" />
+                            <Setter Property="ItemTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
                         </Style>
-                    </Grid.Style>
-
-                    <ItemsControl
-                        x:Name="MultiSelectionControls"
+                    </ItemsControl.Style>
+                </ItemsControl>
+                <Grid Visibility="{Binding IsVisible, ElementName=MultiSelectionControls, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
+                    <ContentControl
                         Margin="2"
-                        ItemsSource="{Binding AudioAPI.SelectedSessions, Source={StaticResource Settings}}"
-                        Visibility="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <ItemsControl.Style>
-                            <Style TargetType="{x:Type ItemsControl}">
+                        Content="{Binding AudioAPI.CurrentSession, Source={StaticResource Settings}}"
+                        Visibility="{Binding AudioAPI.AudioSessionMultiSelector.CurrentSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
+                        <ContentControl.Style>
+                            <Style TargetType="{x:Type ContentControl}">
                                 <Style.Triggers>
                                     <!--  Use display/control hybrid template when only selected sessions are visible  -->
                                     <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                        <Setter Property="ItemTemplate" Value="{StaticResource SessionFullDataTemplate}" />
+                                        <Setter Property="ContentTemplate" Value="{StaticResource SessionFullDataTemplate}" />
                                     </DataTrigger>
                                     <!--  Override last and use display template when control bar isn't visible  -->
                                     <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                        <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                        <Setter Property="ContentTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
                                     </DataTrigger>
                                 </Style.Triggers>
-                                <Setter Property="ItemTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
+                                <Setter Property="ContentTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
                             </Style>
-                        </ItemsControl.Style>
-                    </ItemsControl>
-                    <Grid Visibility="{Binding IsVisible, ElementName=MultiSelectionControls, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
-                        <ContentControl
-                            Margin="2"
-                            Content="{Binding AudioAPI.CurrentSession, Source={StaticResource Settings}}"
-                            Visibility="{Binding AudioAPI.AudioSessionMultiSelector.CurrentSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
-                            <ContentControl.Style>
-                                <Style TargetType="{x:Type ContentControl}">
-                                    <Style.Triggers>
-                                        <!--  Use display/control hybrid template when only selected sessions are visible  -->
-                                        <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                            <Setter Property="ContentTemplate" Value="{StaticResource SessionFullDataTemplate}" />
-                                        </DataTrigger>
-                                        <!--  Override last and use display template when control bar isn't visible  -->
-                                        <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                            <Setter Property="ContentTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                    <Setter Property="ContentTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
-                                </Style>
-                            </ContentControl.Style>
-                        </ContentControl>
-                    </Grid>
+                        </ContentControl.Style>
+                    </ContentControl>
                 </Grid>
             </Grid>
-            <Grid Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
-                <ContentControl
-                    Margin="2"
-                    Content="{Binding AudioAPI.ActiveSession, Source={StaticResource Settings}}"
-                    ContentTemplate="{StaticResource SessionFullDataTemplate}">
-                </ContentControl>
+
+            <Grid Grid.Row="1">
+                <Grid.Style>
+                    <Style TargetType="{x:Type Grid}">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Grid.Style>
+
+                <ItemsControl
+                    x:Name="ActiveSessionControls"
+                    Margin="2">
+                    <ItemsControl.Style>
+                        <Style TargetType="{x:Type ItemsControl}">
+                            <Style.Triggers>
+                                <!--  Use display/control hybrid template when only selected sessions are visible  -->
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
+                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionFullDataTemplate}" />
+                                </DataTrigger>
+                                <!--  Override last and use display template when control bar isn't visible  -->
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
+                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                            <Setter Property="ItemsSource" Value="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}}" />
+                            <Setter Property="ItemTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
+                        </Style>
+                    </ItemsControl.Style>
+                </ItemsControl>
             </Grid>
         </Grid>
     </Border>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -40,11 +40,20 @@
                 <conv:BooleanInverter />
                 <BooleanToVisibilityConverter />
             </conv:ConverterChain>
+            <conv:ConverterChain x:Key="InvertedNullableToVisibilityConverter">
+                <conv:NullToBooleanConverter />
+                <BooleanToVisibilityConverter />
+            </conv:ConverterChain>
             <conv:BooleanInverter x:Key="InvertConverter" />
             <conv:ConverterChain x:Key="InvertedBooleanToVisibilityConverter">
                 <conv:BooleanInverter />
                 <BooleanToVisibilityConverter />
             </conv:ConverterChain>
+            <conv:ConverterChain x:Key="InvertedNullableToBooleanConverter">
+                <conv:NullToBooleanConverter />
+                <conv:BooleanInverter />
+            </conv:ConverterChain>
+            <conv:NullToBooleanConverter x:Key="NullableToBooleanConverter" />
 
             <!--  Styles  -->
             <Style BasedOn="{StaticResource TextBoxStyle}" TargetType="{x:Type TextBox}">
@@ -244,203 +253,215 @@
                     <DataTrigger Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False">
                         <Setter Property="BorderBrush" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
                     </DataTrigger>
+                    <DataTrigger Binding="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToBooleanConverter}}" Value="True">
+                        <Setter Property="BorderBrush" Value="{Binding SessionConfigVM.ActiveAccentBrush, Source={StaticResource Settings}}" />
+                    </DataTrigger>
                 </Style.Triggers>
             </Style>
         </Border.Style>
         <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+            <Grid Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToVisibilityConverter}}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
-            <!--  Row 0 (ListView)  -->
-            <ListView
-                x:Name="ListView"
-                Margin="6,6,6,8"
-                Padding="1"
-                Background="#0000"
-                ItemTemplate="{StaticResource SessionDisplayAlwaysBoldWidthDataTemplate}"
-                ItemsSource="{Binding AudioAPI.AllSessions, Source={StaticResource Settings}, Mode=OneWay}"
-                PreviewMouseDown="ListView_PreviewMouseDown"
-                SelectedIndex="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}"
-                SelectionMode="Single">
-                <i:Interaction.Behaviors>
-                    <wpfBehaviors:MouseWheelListViewBehavior />
-                </i:Interaction.Behaviors>
-                <ListView.Style>
-                    <Style TargetType="{x:Type ListView}">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowFullList, Source={StaticResource Settings}}" Value="False">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                        <Setter Property="BorderThickness" Value="0" />
-                        <Setter Property="Background" Value="#0000" />
-                        <Setter Property="FocusVisualStyle" Value="{StaticResource CustomFocusVisualStyle}" />
-                    </Style>
-                </ListView.Style>
-                <ListView.ItemContainerStyle>
-                    <Style TargetType="{x:Type ListViewItem}">
-                        <Style.Triggers>
-                            <!--  Hide inactive sessions, unless selected  -->
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
-                                    <Condition Binding="{Binding AudioSession.State}" Value="0" />
-                                    <Condition Binding="{Binding IsSelected}" Value="False" />
-                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                            <!--  Selector (Multi-Selection Mode Only):  -->
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="True" />
-                                    <!--  Binds to ListViewItem.IsSelected:  -->
-                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="BorderBrush" Value="{StaticResource TextBoxForeground}" />
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                            <!--  Selector (Single-Selection Mode Only):  -->
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
-                                    <!--  Binds to ListViewItem.IsSelected:  -->
-                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
-                                    <!--  Binds to ListViewItem.IsSelected:  -->
-                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-
-                            <!--  Binds to AudioSessionVM.IsSelected:  -->
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding IsSelected}" Value="True" />
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                            <MultiDataTrigger>
-                                <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding IsSelected}" Value="True" />
-                                    <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
-                                </MultiDataTrigger.Conditions>
-                                <MultiDataTrigger.Setters>
-                                    <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
-                                </MultiDataTrigger.Setters>
-                            </MultiDataTrigger>
-                        </Style.Triggers>
-                        <Setter Property="BorderThickness" Value="1.5" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-                        <Setter Property="Margin" Value="0,1" />
-                        <Setter Property="Padding" Value="6,4" />
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="{x:Type ListViewItem}">
-                                    <Border
-                                        Margin="{TemplateBinding Margin}"
-                                        Padding="{TemplateBinding Padding}"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{StaticResource RoundedControlCorner}"
-                                        FocusVisualStyle="{TemplateBinding FocusVisualStyle}">
-                                        <ContentPresenter
-                                            Content="{TemplateBinding Content}"
-                                            ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
-                                    </Border>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                        <EventSetter Event="Selected" Handler="ListViewItem_Selected" />
-                    </Style>
-                </ListView.ItemContainerStyle>
-            </ListView>
-
-            <!--  Row 1 (Controls)  -->
-            <Grid Grid.Row="1">
-                <Grid.Style>
-                    <Style TargetType="{x:Type Grid}">
-                        <Style.Triggers>
-                            <!--  Hide controls when viewmode doesn't include them  -->
-                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
-                            <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                <Setter Property="Visibility" Value="Visible" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Grid.Style>
-
-                <ItemsControl
-                    x:Name="MultiSelectionControls"
-                    Margin="2"
-                    ItemsSource="{Binding AudioAPI.SelectedSessions, Source={StaticResource Settings}}"
-                    Visibility="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <ItemsControl.Style>
-                        <Style TargetType="{x:Type ItemsControl}">
+                <!--  Row 0 (ListView)  -->
+                <ListView
+                    x:Name="ListView"
+                    Margin="6,6,6,8"
+                    Padding="1"
+                    Background="#0000"
+                    ItemTemplate="{StaticResource SessionDisplayAlwaysBoldWidthDataTemplate}"
+                    ItemsSource="{Binding AudioAPI.AllSessions, Source={StaticResource Settings}, Mode=OneWay}"
+                    PreviewMouseDown="ListView_PreviewMouseDown"
+                    SelectedIndex="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}"
+                    SelectionMode="Single">
+                    <i:Interaction.Behaviors>
+                        <wpfBehaviors:MouseWheelListViewBehavior />
+                    </i:Interaction.Behaviors>
+                    <ListView.Style>
+                        <Style TargetType="{x:Type ListView}">
                             <Style.Triggers>
-                                <!--  Use display/control hybrid template when only selected sessions are visible  -->
-                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionFullDataTemplate}" />
-                                </DataTrigger>
-                                <!--  Override last and use display template when control bar isn't visible  -->
-                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                    <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowFullList, Source={StaticResource Settings}}" Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
                                 </DataTrigger>
                             </Style.Triggers>
-                            <Setter Property="ItemTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Background" Value="#0000" />
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource CustomFocusVisualStyle}" />
                         </Style>
-                    </ItemsControl.Style>
-                </ItemsControl>
-                <Grid Visibility="{Binding IsVisible, ElementName=MultiSelectionControls, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
-                    <ContentControl
+                    </ListView.Style>
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListViewItem}">
+                            <Style.Triggers>
+                                <!--  Hide inactive sessions, unless selected  -->
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
+                                        <Condition Binding="{Binding AudioSession.State}" Value="0" />
+                                        <Condition Binding="{Binding IsSelected}" Value="False" />
+                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <!--  Selector (Multi-Selection Mode Only):  -->
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="True" />
+                                        <!--  Binds to ListViewItem.IsSelected:  -->
+                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="BorderBrush" Value="{StaticResource TextBoxForeground}" />
+                                        <Setter Property="FontWeight" Value="Bold" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <!--  Selector (Single-Selection Mode Only):  -->
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
+                                        <!--  Binds to ListViewItem.IsSelected:  -->
+                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                        <Setter Property="FontWeight" Value="Bold" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}}" Value="False" />
+                                        <!--  Binds to ListViewItem.IsSelected:  -->
+                                        <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="True" />
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
+                                        <Setter Property="FontWeight" Value="Bold" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+
+                                <!--  Binds to AudioSessionVM.IsSelected:  -->
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding IsSelected}" Value="True" />
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="True" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Background" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding IsSelected}" Value="True" />
+                                        <Condition Binding="{Binding AudioAPI.AudioSessionMultiSelector.LockSelection, Source={StaticResource Settings}}" Value="False" />
+                                    </MultiDataTrigger.Conditions>
+                                    <MultiDataTrigger.Setters>
+                                        <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
+                                    </MultiDataTrigger.Setters>
+                                </MultiDataTrigger>
+                            </Style.Triggers>
+                            <Setter Property="BorderThickness" Value="1.5" />
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                            <Setter Property="Margin" Value="0,1" />
+                            <Setter Property="Padding" Value="6,4" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                        <Border
+                                            Margin="{TemplateBinding Margin}"
+                                            Padding="{TemplateBinding Padding}"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="{StaticResource RoundedControlCorner}"
+                                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}">
+                                            <ContentPresenter
+                                                Content="{TemplateBinding Content}"
+                                                ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+                                        </Border>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                            <EventSetter Event="Selected" Handler="ListViewItem_Selected" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                </ListView>
+
+                <!--  Row 1 (Controls)  -->
+                <Grid Grid.Row="1" Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource InvertedNullableToVisibilityConverter}}">
+                    <Grid.Style>
+                        <Style TargetType="{x:Type Grid}">
+                            <Style.Triggers>
+                                <!--  Hide controls when viewmode doesn't include them  -->
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Grid.Style>
+
+                    <ItemsControl
+                        x:Name="MultiSelectionControls"
                         Margin="2"
-                        Content="{Binding AudioAPI.CurrentSession, Source={StaticResource Settings}}"
-                        Visibility="{Binding AudioAPI.AudioSessionMultiSelector.CurrentSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
-                        <ContentControl.Style>
-                            <Style TargetType="{x:Type ContentControl}">
+                        ItemsSource="{Binding AudioAPI.SelectedSessions, Source={StaticResource Settings}}"
+                        Visibility="{Binding AudioAPI.AudioSessionMultiSelector.HasSelectedSessions, Source={StaticResource Settings}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ItemsControl.Style>
+                            <Style TargetType="{x:Type ItemsControl}">
                                 <Style.Triggers>
                                     <!--  Use display/control hybrid template when only selected sessions are visible  -->
                                     <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
-                                        <Setter Property="ContentTemplate" Value="{StaticResource SessionFullDataTemplate}" />
+                                        <Setter Property="ItemTemplate" Value="{StaticResource SessionFullDataTemplate}" />
                                     </DataTrigger>
                                     <!--  Override last and use display template when control bar isn't visible  -->
                                     <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
-                                        <Setter Property="ContentTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                        <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
                                     </DataTrigger>
                                 </Style.Triggers>
-                                <Setter Property="ContentTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
+                                <Setter Property="ItemTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
                             </Style>
-                        </ContentControl.Style>
-                    </ContentControl>
+                        </ItemsControl.Style>
+                    </ItemsControl>
+                    <Grid Visibility="{Binding IsVisible, ElementName=MultiSelectionControls, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
+                        <ContentControl
+                            Margin="2"
+                            Content="{Binding AudioAPI.CurrentSession, Source={StaticResource Settings}}"
+                            Visibility="{Binding AudioAPI.AudioSessionMultiSelector.CurrentSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
+                            <ContentControl.Style>
+                                <Style TargetType="{x:Type ContentControl}">
+                                    <Style.Triggers>
+                                        <!--  Use display/control hybrid template when only selected sessions are visible  -->
+                                        <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowSelectedOnly, Source={StaticResource Settings}}" Value="True">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource SessionFullDataTemplate}" />
+                                        </DataTrigger>
+                                        <!--  Override last and use display template when control bar isn't visible  -->
+                                        <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
+                                            <Setter Property="ContentTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                    <Setter Property="ContentTemplate" Value="{StaticResource SessionControlsDataTemplate}" />
+                                </Style>
+                            </ContentControl.Style>
+                        </ContentControl>
+                    </Grid>
                 </Grid>
+            </Grid>
+            <Grid Visibility="{Binding AudioAPI.AudioSessionMultiSelector.ActiveSession, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource NullableToVisibilityConverter}}">
+                <ContentControl
+                    Margin="2"
+                    Content="{Binding AudioAPI.ActiveSession, Source={StaticResource Settings}}"
+                    ContentTemplate="{StaticResource SessionFullDataTemplate}">
+                </ContentControl>
             </Grid>
         </Grid>
     </Border>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -143,13 +143,10 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
                         FontSize="13"
-                        Text="{Binding Name}">
+                        Text="{Binding AudioSession.FlowName}">
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding AudioSession.DataFlow}" Value="Capture">
-                                        <Setter Property="FontStyle" Value="Oblique" />
-                                    </DataTrigger>
                                     <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
                                         <Setter Property="Foreground" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
                                     </DataTrigger>
@@ -185,13 +182,10 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Center"
                         FontSize="13"
-                        Text="{Binding Name}">
+                        Text="{Binding AudioSession.FlowName}">
                         <TextBlock.Style>
                             <Style TargetType="{x:Type TextBlock}">
                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding AudioSession.DataFlow}" Value="Capture">
-                                        <Setter Property="FontStyle" Value="Oblique" />
-                                    </DataTrigger>
                                     <DataTrigger Binding="{Binding AudioSession.State, UpdateSourceTrigger=PropertyChanged}" Value="0">
                                         <Setter Property="Foreground" Value="{Binding SessionConfigVM.LockedAccentBrush, Source={StaticResource Settings}}" />
                                     </DataTrigger>

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -282,11 +282,13 @@
                 <ListView.ItemContainerStyle>
                     <Style TargetType="{x:Type ListViewItem}">
                         <Style.Triggers>
-                            <!--  Hide inactive sessions  -->
+                            <!--  Hide inactive sessions, unless selected  -->
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>
                                     <Condition Binding="{Binding HideInactiveSessions, Source={StaticResource Settings}}" Value="True" />
                                     <Condition Binding="{Binding AudioSession.State}" Value="0" />
+                                    <Condition Binding="{Binding IsSelected}" Value="False" />
+                                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
                                 </MultiDataTrigger.Conditions>
                                 <MultiDataTrigger.Setters>
                                     <Setter Property="Visibility" Value="Collapsed" />

--- a/VolumeControl/SessionListNotification.xaml
+++ b/VolumeControl/SessionListNotification.xaml
@@ -273,7 +273,6 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <!--  Row 0 (ListView)  -->
@@ -284,7 +283,6 @@
                 Background="#0000"
                 ItemTemplate="{StaticResource SessionDisplayAlwaysBoldWidthDataTemplate}"
                 PreviewMouseDown="ListView_PreviewMouseDown"
-                SelectedIndex="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}"
                 SelectionMode="Single">
                 <i:Interaction.Behaviors>
                     <wpfBehaviors:MouseWheelListViewBehavior />
@@ -292,6 +290,7 @@
                 <ListView.Style>
                     <Style TargetType="{x:Type ListView}">
                         <Setter Property="ItemsSource" Value="{Binding AudioAPI.AllSessions, Source={StaticResource Settings}, Mode=OneWay}" />
+                        <Setter Property="SelectedIndex" Value="{Binding AudioAPI.AudioSessionMultiSelector.CurrentIndex, Source={StaticResource Settings}, UpdateSourceTrigger=PropertyChanged}" />
                         <Setter Property="BorderThickness" Value="0" />
                         <Setter Property="Background" Value="#0000" />
                         <Setter Property="FocusVisualStyle" Value="{StaticResource CustomFocusVisualStyle}" />
@@ -301,6 +300,7 @@
                             </DataTrigger>
                             <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
                                 <Setter Property="ItemsSource" Value="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay}" />
+                                <Setter Property="SelectedIndex" Value="-1" />
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
@@ -388,6 +388,15 @@
                                     <Setter Property="Background" Value="{Binding SessionConfigVM.UnlockedAccentBrush, Source={StaticResource Settings}}" />
                                 </MultiDataTrigger.Setters>
                             </MultiDataTrigger>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True" />
+                                </MultiDataTrigger.Conditions>
+                                <MultiDataTrigger.Setters>
+                                    <Setter Property="Background" Value="{Binding SessionConfigVM.ActiveAccentBrush, Source={StaticResource Settings}}" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </MultiDataTrigger.Setters>
+                            </MultiDataTrigger>
                         </Style.Triggers>
                         <Setter Property="BorderThickness" Value="1.5" />
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -452,9 +461,6 @@
                                 <!--  Override last and use display template when control bar isn't visible  -->
                                 <DataTrigger Binding="{Binding SessionConfigVM.FlagsVM.ShowControlBar, Source={StaticResource Settings}}" Value="False">
                                     <Setter Property="ItemTemplate" Value="{StaticResource SessionDisplayDataTemplate}" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay, Converter={StaticResource ListHasItemsBooleanConverter}}" Value="True">
-                                    <Setter Property="ItemsSource" Value="{Binding AudioAPI.ActiveSessions, Source={StaticResource Settings}, Mode=OneWay}" />
                                 </DataTrigger>
                             </Style.Triggers>
                             <Setter Property="ItemsSource" Value="{Binding AudioAPI.SelectedSessions, Source={StaticResource Settings}}" />

--- a/VolumeControl/SessionListNotification.xaml.cs
+++ b/VolumeControl/SessionListNotification.xaml.cs
@@ -10,6 +10,7 @@ using VolumeControl.Core.Enum;
 using VolumeControl.Core.Extensions;
 using VolumeControl.Core.Input.Enums;
 using VolumeControl.Log;
+using VolumeControl.SDK;
 using VolumeControl.SDK.Internal;
 using VolumeControl.TypeExtensions;
 using VolumeControl.ViewModels;
@@ -197,6 +198,7 @@ namespace VolumeControl
                 base.Hide();
             });
             SavePosition();
+            VCSettings.AudioAPI.ActiveSessions.Clear();
         }
         #endregion Show/Hide
 
@@ -446,6 +448,7 @@ namespace VolumeControl
             _fadingIn = false;
             this.Opacity = 1.0; //< reset Opacity property now that we're done with it; this fixes a bug when FadeIn is disabled.
             SavePosition();
+            VCSettings.AudioAPI.ActiveSessions.Clear();
         }
         #endregion Storyboards
 

--- a/VolumeControl/SessionListNotification.xaml.cs
+++ b/VolumeControl/SessionListNotification.xaml.cs
@@ -197,7 +197,6 @@ namespace VolumeControl
                 base.Hide();
             });
             SavePosition();
-            VCSettings.AudioAPI.AudioSessionMultiSelector.ActiveSession = null;
         }
         #endregion Show/Hide
 
@@ -447,7 +446,6 @@ namespace VolumeControl
             _fadingIn = false;
             this.Opacity = 1.0; //< reset Opacity property now that we're done with it; this fixes a bug when FadeIn is disabled.
             SavePosition();
-            VCSettings.AudioAPI.AudioSessionMultiSelector.ActiveSession = null;
         }
         #endregion Storyboards
 

--- a/VolumeControl/SessionListNotification.xaml.cs
+++ b/VolumeControl/SessionListNotification.xaml.cs
@@ -60,6 +60,7 @@ namespace VolumeControl
 
             VCSettings.SessionConfigVM.FlagsVM.StateChanged += this.FlagsVM_StateChanged;
             VCSettings.AudioAPI.AudioSessionMultiSelector.CurrentSessionChanged += this.AudioSessionMultiSelector_CurrentSessionChanged;
+            VCSettings.AudioAPI.AudioSessionMultiSelector.ActiveSessionChanged += this.AudioSessionMultiSelector_ActiveSessionChanged;
             VCSettings.AudioAPI.AudioSessionMultiSelector.SessionSelected += this.AudioSessionMultiSelector_SessionSelectedOrDeselected;
             VCSettings.AudioAPI.AudioSessionMultiSelector.SessionDeselected += this.AudioSessionMultiSelector_SessionSelectedOrDeselected;
 
@@ -196,6 +197,7 @@ namespace VolumeControl
                 base.Hide();
             });
             SavePosition();
+            VCSettings.AudioAPI.AudioSessionMultiSelector.ActiveSession = null;
         }
         #endregion Show/Hide
 
@@ -445,6 +447,7 @@ namespace VolumeControl
             _fadingIn = false;
             this.Opacity = 1.0; //< reset Opacity property now that we're done with it; this fixes a bug when FadeIn is disabled.
             SavePosition();
+            VCSettings.AudioAPI.AudioSessionMultiSelector.ActiveSession = null;
         }
         #endregion Storyboards
 
@@ -545,6 +548,13 @@ namespace VolumeControl
 
         #region AudioSessionMultiSelector
         private void AudioSessionMultiSelector_CurrentSessionChanged(object? sender, CoreAudio.AudioSession? e)
+        {
+            if (e != null) return;
+
+            if (IsHiddenByViewMode)
+                HideNowNoFadeOut();
+        }
+        private void AudioSessionMultiSelector_ActiveSessionChanged(object? sender, CoreAudio.AudioSession? e)
         {
             if (e != null) return;
 

--- a/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
+++ b/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
@@ -63,8 +63,6 @@ namespace VolumeControl.ViewModels
             // attach handlers for sessions being added/removed at runtime
             AudioSessionManager.AddedSessionToList += this.AudioSessionManager_AddedSessionToList;
             AudioSessionManager.RemovedSessionFromList += this.AudioSessionManager_RemovedSessionFromList;
-            AudioSessionManager.AddedSessionToHiddenList += this.AudioSessionManager_AddedSessionToList;
-            AudioSessionManager.RemovedSessionFromHiddenList += this.AudioSessionManager_RemovedSessionFromList;
 
             // attach handler to override session names
             AudioSessionManager.PreviewSessionName += this.AudioSessionManager_PreviewSessionName;

--- a/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
+++ b/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualBasic.Devices;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -57,6 +58,7 @@ namespace VolumeControl.ViewModels
 
             // setup the sessions list
             AllSessions = new();
+            ActiveSessions = new();
 
             // attach handlers for sessions being added/removed at runtime
             AudioSessionManager.AddedSessionToList += this.AudioSessionManager_AddedSessionToList;
@@ -132,7 +134,7 @@ namespace VolumeControl.ViewModels
         public ObservableImmutableList<AudioSessionVM> SelectedSessions { get; }
         public Comparer<AudioSessionVM> SelectedSessionsComparer { get; }
         public AudioSessionVM? CurrentSession { get; set; }
-        public AudioSessionVM? ActiveSession { get; set; }
+        public ObservableImmutableList<AudioSessionVM> ActiveSessions { get; }
         public AudioDeviceSelector AudioDeviceSelector { get; }
         public AudioDeviceVM? SelectedDevice { get; set; }
         public AudioSessionMultiSelector AudioSessionMultiSelector { get; }
@@ -287,13 +289,17 @@ namespace VolumeControl.ViewModels
             // update the all selected checkbox
             NotifyPropertyChanged(nameof(AllSessionsSelected));
         }
+        private void AudioSessionMultiSelector_ActiveSessionChanged(object? sender, AudioSession? e)
+        {
+            if (e != null)
+                ActiveSessions.AddIfUnique(GetAudioSessionVM(e)!);
+            else
+                ActiveSessions.Clear();
+            NotifyPropertyChanged(nameof(ActiveSessions));
+        }
         private void AudioSessionMultiSelector_CurrentSessionChanged(object? sender, AudioSession? e)
         {
             CurrentSession = e == null ? null : GetAudioSessionVM(e);
-        }
-        private void AudioSessionMultiSelector_ActiveSessionChanged(object? sender, AudioSession? e)
-        {
-            ActiveSession = e == null ? null : GetAudioSessionVM(e);
         }
         #endregion AudioSessionMultiSelector
 

--- a/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
+++ b/VolumeControl/ViewModels/AudioDeviceManagerVM.cs
@@ -57,13 +57,12 @@ namespace VolumeControl.ViewModels
 
             // setup the sessions list
             AllSessions = new();
-            HiddenSessions = new();
 
             // attach handlers for sessions being added/removed at runtime
             AudioSessionManager.AddedSessionToList += this.AudioSessionManager_AddedSessionToList;
             AudioSessionManager.RemovedSessionFromList += this.AudioSessionManager_RemovedSessionFromList;
-            AudioSessionManager.AddedSessionToHiddenList += this.AudioSessionManager_AddedSessionToHiddenList;
-            AudioSessionManager.RemovedSessionFromHiddenList += this.AudioSessionManager_RemovedSessionFromHiddenList;
+            AudioSessionManager.AddedSessionToHiddenList += this.AudioSessionManager_AddedSessionToList;
+            AudioSessionManager.RemovedSessionFromHiddenList += this.AudioSessionManager_RemovedSessionFromList;
 
             // attach handler to override session names
             AudioSessionManager.PreviewSessionName += this.AudioSessionManager_PreviewSessionName;
@@ -130,7 +129,6 @@ namespace VolumeControl.ViewModels
         public ObservableImmutableList<AudioDeviceVM> Devices { get; }
         public CoreAudio.AudioSessionManager AudioSessionManager { get; }
         public ObservableImmutableList<AudioSessionVM> AllSessions { get; }
-        public ObservableImmutableList<AudioSessionVM> HiddenSessions { get; }
         public ObservableImmutableList<AudioSessionVM> SelectedSessions { get; }
         public Comparer<AudioSessionVM> SelectedSessionsComparer { get; }
         public AudioSessionVM? CurrentSession { get; set; }
@@ -183,7 +181,7 @@ namespace VolumeControl.ViewModels
         /// <param name="audioSession">An <see cref="AudioSession"/> instance.</param>
         /// <returns>The <see cref="AudioSessionVM"/> instance associated with the given session, or <see langword="null"/> if it wasn't found.</returns>
         public AudioSessionVM? GetAudioSessionVM(AudioSession audioSession)
-            => AllSessions.FirstOrDefault(audioSessionVM => audioSessionVM!.AudioSession.Equals(audioSession), HiddenSessions.FirstOrDefault(audioSessionVM => audioSessionVM!.AudioSession.Equals(audioSession), null));
+            => AllSessions.FirstOrDefault(audioSessionVM => audioSessionVM!.AudioSession.Equals(audioSession), null);
         #endregion Methods
 
         #region EventHandlers
@@ -221,19 +219,6 @@ namespace VolumeControl.ViewModels
                 vm.Dispose();
             }
             NotifyPropertyChanged(nameof(AllSessionsSelected));
-        }
-        private void AudioSessionManager_AddedSessionToHiddenList(object? sender, AudioSession e)
-        {
-            Dispatcher.Invoke(() => HiddenSessions.Add(new AudioSessionVM(this, e)));
-        }
-        private void AudioSessionManager_RemovedSessionFromHiddenList(object? sender, AudioSession e)
-        {
-            // check if the vm actually exists to prevent possible exception in rare cases
-            if (HiddenSessions.FirstOrDefault(svm => svm.AudioSession.Equals(e)) is AudioSessionVM vm)
-            {
-                HiddenSessions.Remove(vm);
-                vm.Dispose();
-            }
         }
         private void AudioSessionManager_PreviewSessionName(object sender, PreviewSessionNameEventArgs e)
         {

--- a/VolumeControl/ViewModels/AudioSessionVM.cs
+++ b/VolumeControl/ViewModels/AudioSessionVM.cs
@@ -27,6 +27,7 @@ namespace VolumeControl.ViewModels
             // update bindings on the IsSelected property when this session is selected or deselected
             manager.AudioSessionMultiSelector.SessionSelected += this.AudioSessionMultiSelector_SessionSelected_SessionDeselected;
             manager.AudioSessionMultiSelector.SessionDeselected += this.AudioSessionMultiSelector_SessionSelected_SessionDeselected;
+            manager.AudioSessionMultiSelector.ActiveSessionChanged += this.AudioSessionMultiSelector_ActiveSessionChanged;
         }
         #endregion Constructor
 
@@ -66,6 +67,10 @@ namespace VolumeControl.ViewModels
                 _isSelectedChanging = false;
                 NotifyPropertyChanged();
             }
+        }
+        public bool IsActive
+        {
+            get => AudioDeviceManagerVM.AudioSessionMultiSelector.GetSessionIsActive(this.AudioSession);
         }
         #endregion Properties
 
@@ -117,6 +122,10 @@ namespace VolumeControl.ViewModels
             {
                 NotifyPropertyChanged(nameof(IsSelected));
             }
+        }
+        private void AudioSessionMultiSelector_ActiveSessionChanged(object? sender, AudioSession? e)
+        {
+            NotifyPropertyChanged(nameof(IsActive));
         }
         #endregion AudioSessionMultiSelector
 

--- a/VolumeControl/ViewModels/AudioSessionVM.cs
+++ b/VolumeControl/ViewModels/AudioSessionVM.cs
@@ -68,10 +68,6 @@ namespace VolumeControl.ViewModels
                 NotifyPropertyChanged();
             }
         }
-        public bool IsActive
-        {
-            get => AudioDeviceManagerVM.AudioSessionMultiSelector.GetSessionIsActive(this.AudioSession);
-        }
         #endregion Properties
 
         #region Methods
@@ -125,7 +121,7 @@ namespace VolumeControl.ViewModels
         }
         private void AudioSessionMultiSelector_ActiveSessionChanged(object? sender, AudioSession? e)
         {
-            NotifyPropertyChanged(nameof(IsActive));
+            NotifyPropertyChanged("ActiveSessions");
         }
         #endregion AudioSessionMultiSelector
 

--- a/VolumeControl/ViewModels/ListNotificationConfigSectionVM.cs
+++ b/VolumeControl/ViewModels/ListNotificationConfigSectionVM.cs
@@ -21,6 +21,7 @@ namespace VolumeControl.ViewModels
         public NotificationViewFlagsVM FlagsVM { get; }
         public Brush LockedAccentBrush => new SolidColorBrush(ConfigSection.LockedColor);
         public Brush UnlockedAccentBrush => new SolidColorBrush(ConfigSection.UnlockedColor);
+        public Brush ActiveAccentBrush => new SolidColorBrush(ConfigSection.ActiveColor);
         public Brush BackgroundBrush => new SolidColorBrush(ConfigSection.BackgroundColor);
         public Brush ForegroundBrush => new SolidColorBrush(ConfigSection.TextColor);
         #endregion Properties
@@ -44,6 +45,10 @@ namespace VolumeControl.ViewModels
             else if (e.PropertyName.Equals(nameof(NotificationConfigSection.UnlockedColor), System.StringComparison.Ordinal))
             {
                 NotifyPropertyChanged(nameof(UnlockedAccentBrush));
+            }
+            else if (e.PropertyName.Equals(nameof(NotificationConfigSection.ActiveColor), System.StringComparison.Ordinal))
+            {
+                NotifyPropertyChanged(nameof(ActiveAccentBrush));
             }
             else if (e.PropertyName.Equals(nameof(NotificationConfigSection.BackgroundColor), System.StringComparison.Ordinal))
             {

--- a/VolumeControl/ViewModels/NotificationViewFlagsVM.cs
+++ b/VolumeControl/ViewModels/NotificationViewFlagsVM.cs
@@ -16,6 +16,7 @@ namespace VolumeControl.ViewModels
 
             ConfigSection.PropertyChanged += this.ConfigSection_PropertyChanged;
             StateChanged += this.ListNotificationViewFlagsVM_StateChanged;
+            State = configSection.ViewMode; // I don't know what's going on, but the notification is not behaving correctly unless you go untick and tick All Items again...
         }
         #endregion Constructor
 


### PR DESCRIPTION
When routing the W10 per-app audio output to a non-default device, some applications will open (inactive) sessions to multiple devices. Or some complex apps might do so on purpose. VC treats these sessions as duplicates even though they are on different outputs, which means only the first session can be adjusted, and it's usually the wrong one.

So I fixed that...

This PR:

- makes the duplicate check actually look for duplicate sessions, not only processes
- highlights inactive sessions in lists
- adds a setting to hide/ignore inactive sessions in the notification and next/previous hotkeys
- adds device name and flow direction to mixer and session notification
- adds a hotkey action to simply show a notification without changing anything
- fixes #159
- targets all sessions when using target overrides (fixes #153)
- adds active application notification, also used for target overrides (fixes #118)

Haven't tested this a lot, just what I have running currently, but then again there's not much to test. I also don't really know what I'm doing, so I might be doing something silly.

![image](https://github.com/radj307/volume-control/assets/4947943/46ea6ddf-88b8-4555-9a87-513111eb5542)
Some more clutter in the mixer, but not in the notification!