### PR TITLE
Spanish translations for Volume Control

### DIFF
--- a/VolumeControl/Localization/es.loc.json
+++ b/VolumeControl/Localization/es.loc.json
@@ -1,0 +1,576 @@
+{
+    "$LanguageName": "Español (Spanish)",
+  
+    "VolumeControl": {
+      "MainWindow": {
+        "CaptionBar": {
+          "Title": {
+            "Content": "Volume Control"          
+          },
+          "BugReport": {
+            "Content": "✏",
+            "Tooltip": "Informar de un error"
+          }
+        },
+        "Mixer": {
+          "TabHeader": "Mixer",
+          "TargetBox": {
+            "Watermark": "ID del proceso o nombre",
+            "LockTarget": "Bloquear"
+          },
+          "MixerGrid": {
+            "Selected": {
+              "Header": {
+                "Tooltip": "(De)seleccionar todo"
+              }
+            },
+            "PID": {
+              "Header": "ID Proceso"
+            },
+            "Name": {
+              "Header": "Nombre"
+            },
+            "Mute": {
+              "Header": "Silenciar"
+            },
+            "Volume": {
+              "Header": "Volumen"
+            },
+            "Select": {
+              "Button": "Seleccionar"
+            }
+          }
+        },
+        "Hotkeys": {
+          "TabHeader": "Atajos",
+          "ControlRow": {
+            "VolumeStep": {
+              "Content": "Intervalo de volumen",
+              "Tooltip": "Este número corresponde a la cantidad de volumen que se resta o se suma cada vez que presionas las teclas de subir o bajar volumen."
+            },
+            "ResetToDefault": {
+              "Content": "Ripristina predefiniti",
+              "Tooltip": "Ripristina tutti i tasti scelta rapida alle impostazioni predefinite."
+            }
+          },
+          "HotkeyGrid": {
+            "Active": {
+              "Header": {
+                "Tooltip": "Questo (annulla) la registrazione di tutti i tasti di scelta rapida nell'elenco."
+              }
+            },
+            "Name": {
+              "Header": "Nome"
+            },
+            "Key": {
+              "Header": "Chiave",
+              "KeySelector": {
+                "Content": "🖮",
+                "Tooltip": "Fai clic e tieni premuto con il mouse, quindi premi un tasto per selezionarlo.\nI tasti scelta rapida registrati possono comunque essere attivati."
+              }
+            },
+            "Alt": {
+              "Header": "Alt"
+            },
+            "Ctrl": {
+              "Header": "Ctrl"
+            },
+            "Shift": {
+              "Header": "Maiusc"
+            },
+            "Windows": {
+              "Header": "Win"
+            },
+            "Action": {
+              "Header": "Azione"
+            }
+          },
+          "CreateNewHotkeyButton": {
+            "Content": "Crea nuovo tasto rapido",
+            "Tooltip": "Crea un nuovo tasto di scelta rapida vuoto."
+          }
+        },
+        "Settings": {
+          "TabHeader": "Impostazioni",
+          "Language": {
+            "Header": "Lingua",
+            "CustomLocations": "Percorso personalizzato",
+            "Reload": {
+              "Content": "Ricarica",
+              "Tooltip": "Ricarica tutti i file di configurazione della lingua dal disco."
+            }
+          },
+          "Audio": {
+            "Header": "Audio",
+            "AdditionalSettings": {
+              "Header": {
+                "Content": "Impostazioni aggiuntive",
+                "Tooltip": {}
+              },
+              "ShowPeakMeters": {
+                "Content": "Visualizza misuratori picco",
+                "Tooltip": "Attiva/disattiva misuratori picco audio nel mixer."
+              },
+              "UpdateInterval": {
+                "Content": "Intervallo aggiornamento",
+                "Tooltip": "La quantità di tempo, in millisecondi, tra ogni aggiornamento dei misuratori picco nel mixer."
+              },
+              "EnableDeviceControl": {
+                "Content": "Visualizza controlli dispositivo",
+                "Tooltip": "Attiva/disattiva visualizzazione controlli volume e muto nella sezione Dispositivi audio."
+              },
+              "HiddenSessions": {
+                "Content": "Sessioni nascoste",
+                "Tooltip": {}
+              }
+            },
+            "DeviceGrid": {
+              "Enabled": {
+                "Header": {
+                  "Tooltip": "Qui puoi includere o escludere dispositivi audio specifici."
+                },
+                "Tooltip": "Qui puoi includere o escludere dispositivi specifici."
+              },
+              "Name": {
+                "Header": "Nome dispositivo"
+              },
+              "Interface": {
+                "Header": "Nome interfaccia"
+              },
+              "Mute": {
+                "Header": "Audio off"
+              },
+              "Volume": {
+                "Header": "Volume"
+              }
+            }
+          },
+          "Notifications": {
+            "Header": "Notifiche",
+            "AdditionalSettings": {
+              "Header": {
+                "Content": "Impostazioni aggiuntive",
+                "Tooltip": {}
+              },
+              "ResetPosition": {
+                "Content": "Ripristina Posizione",
+                "Tooltip": "Reimpostare la posizione della notifica dell'elenco nel caso in cui scompaia dal riquadro di visualizzazione."
+              },
+              "ForceHide": {
+                "Content": "Nascondi",
+                "Tooltip": "Forza la scomparsa della finestra di notifica."
+              },
+              "HiddenSessions": {
+                "Content": "Nascondi sessioni",
+                "Tooltip": {}
+              }
+            },
+            "Enable": {
+              "Content": "Abilita",
+              "Tooltip": "Attiva/disattiva la visualizzazione delle notifiche quando si cambia la sessione destinazione."
+            },
+            "OnVolumeChange": {
+              "Content": "Al cambio di volume",
+              "Tooltip": "Quando questa opzione è selezionata, vengono visualizzate anche le notifiche quando viene modificato il livello del volume destinazione."
+            },
+            "Timeout": {
+              "Content": "Timeout",
+              "Tooltip": "La quantità di tempo in millisecondi durante la quale le notifiche rimarranno visibili dopo essere state attivate."
+            },
+            "SessionListNotificationConfig": {
+              "Header": {
+                "Content": "Opzioni notifica sessioni",
+                "Tooltip": {}
+              }
+            },
+            "DeviceListNotificationConfig": {
+              "Header": {
+                "Content": "Opzioni notifica dispositivo",
+                "Tooltip": {}
+              }
+            },
+            "ColorPicker": {
+              "Background": {
+                "Tooltip": "Imposta il colore di sfondo della finestra di notifica."
+              },
+              "Foreground": {
+                "Tooltip": "Imposta il colore del testo della finestra di notifica."
+              },
+              "LockedAccent": {
+                "Tooltip": "Imposta il colore di evidenziazione della finestra di notifica quando la selezione è bloccata."
+              },
+              "UnlockedAccent": {
+                "Tooltip": "Imposta il colore di evidenziazione della finestra di notifica quando la selezione è sbloccata."
+              }
+            },
+            "CornerRadius": {
+              "Content": "Raggio angolo:",
+              "Tooltip": "Il raggio degli angoli della finestra di notifica.\nInizia dall'angolo in alto a sinistra e procede in senso orario."
+            }
+          },
+          "Log": {
+            "Header": "Registrazione eventi",
+            "Enable": {
+              "Content": "Abilita"
+            },
+            "Filter": {
+              "Text": "Filtro"
+            },
+            "Path": {
+              "Tooltip": "Specifica il percorso e il nome del file registro.\nI percorsi relativi sono relativi alla posizione dell'eseguibile.",
+              "WatermarkText": "percorso file registro eventi"
+            },
+            "OpenButton": {
+              "Content": "Apri",
+              "Tooltip": "Apri il file registro eventi nell'applicazione predefinita."
+            }
+          },
+          "Application": {
+            "Header": "Applicazione",
+            "RunAtStartup": {
+              "Content": "Esegui all'avvio del sistema",
+              "Tooltip": "Quando abilitato, il controllo del volume verrà eseguito all'accesso del sistema.",
+              "AltTooltip": "Un'altra istanza di Controllo volume è impostata per essere eseguita all'avvio.\nLa modifica di questo lo sostituirà."
+            },
+            "StartMinimized": {
+              "Content": "Avvia minimizzato",
+              "Tooltip": "Quando abilitato, il controllo del volume verrà minimizzato dopo l'esecuzione."
+            },
+            "MultiInstance": {
+              "Content": "Multi-Istanza",
+              "Tooltip": "Consenti l'esecuzione simultanea di più istanze di Volume Control, a condizione che utilizzino un file di configurazione diverso."
+            },
+            "ShowInTaskbar": {
+              "Content": "Visualizza nella barra sistema",
+              "Tooltip": {}
+            },
+            "AlwaysOnTop": {
+              "Content": "Sempre in primo piano",
+              "Tooltip": {}
+            },
+            "ShowIcons": {
+              "Content": "Visualizza icone",
+              "Tooltip": "Quando abilitato, il programma tenterà di visualizzare l'icona associata ai dispositivi audio e alle sessioni (durante l'esecuzione come utente potrebbero mancare alcune icone )."
+            },
+            "KeepRelativePosition": {
+              "Content": "Mantieni posizione relativa",
+              "Tooltip": "Quando la dimensione della finestra cambia mantieni la finestra principale nella stessa posizione rispetto all'angolo dello schermo più vicino "
+            },
+            "RestorePosition": {
+              "Content": "Ripristina posizione",
+              "Tooltip": "Ripristina la posizione precedente della finestra principale all'avvio del programma."
+            },
+            "EnableInputDevices": {
+              "Content": "Supporto ingresso audio",
+              "Tooltip": "Abilita il supporto per dispositivi di acquisizione e sessioni che registrano audio."
+            }
+          },
+          "Updates": {
+            "Header": "Aggiornamenti",
+            "CheckNow": {
+              "Content": "Controlla",
+              "Tooltip": "Controlla manualmente la disponibilità di nuove versioni di Volume Control."
+            },
+            "OnStartup": {
+              "Content": "All'avvio",
+              "Tooltip": "All'avvio verifica disponibilità aggiornamenti del programma."
+            },
+            "ShowPrompt": {
+              "Content": "Visualizza prompt",
+              "Tooltip": "Quando questa opzione è selezionata, verrà richiesto di aggiornare sotto forma di una finestra di messaggio; altrimenti vedrai un'icona nell'angolo in alto a destra."
+            }
+          }
+        },
+        "About": {
+          "TabHeader": "Info sul programma",
+          "ReportABug": {
+            "Content": "Segnala un bug",
+            "Tooltip": "Facci sapere se qualcosa non funziona correttamente"
+          },
+          "OpenWebsite": {
+            "Content": "Sito web ufficiale",
+            "Tooltip": "Apri il sito web ufficiale di Volume Control nel browser predefinito"
+          },
+          "ShowDebugInfo": {
+            "Header": {
+              "Content": "Visualizza informazioni di debug",
+              "Tooltip": {}
+            },
+            "ConfigPath": {
+              "Content": {
+                "Italiano (Italian)": ""
+              },
+              "Tooltip": {
+                "Italiano (Italian)": ""
+              }
+            }
+          }
+        }
+      },
+  
+      "ListNotification": {
+        "Options": {
+          "Header": "Opzioni",
+          "ShowControls": {
+            "Content": "Visualizza controlli",
+            "Tooltip": "Attiva/disattiva visualizzazione controlli avanzati accanto agli elementi dell'elenco."
+          },
+          "DragRequiresAlt": {
+            "Content": "Trascina richiede uso 'Alt'",
+            "Tooltip": "Quando selezionato, il tasto ALT deve essere tenuto premuto per poter trascinare la finestra di notifica con il mouse."
+          },
+          "SavePosition": {
+            "Content": "Salva posizione",
+            "Tooltip": {}
+          },
+          "DoFadeIn": {
+            "Content": "Dissolvenza iniziale",
+            "Tooltip": "Se selezionata, la finestra di notifica visualizza un'animazione dissolvenza iniziale invece di apparire istantaneamente."
+          },
+          "FadeInDuration": {
+            "Tooltip": "Specifica la durata in millisecondi dell'animazione dissolvenza iniziale."
+          },
+          "DoFadeOut": {
+            "Content": "Dissolvenza finale",
+            "Tooltip": "Se selezionata, la finestra di notifica visualizza un'animazione dissolvenza finale invece di scomparire all'istante."
+          },
+          "FadeOutDuration": {
+            "Tooltip": "Specifica la durata in millisecondi dell'animazione dissolvenza finale."
+          }
+        }
+      },
+  
+      "ActionSettingsWindow": {
+        "DataTemplateErrorTextBlock": {
+          "Tooltip": "Non è disponibile nessun ModelloDati per questo tipo di valore!"
+        },
+        "ToggleActionSetting": {
+          "Content": "Abilita",
+          "Tooltip": "Questa impostazione di azione è abilitata quando selezionata."
+        },
+        "ActionTargetSpecifierDataTemplate": {
+          "AddTargetBox": {
+            "DefaultText": "Nome destinazione..."
+          }
+        }
+      },
+  
+      "Dialogs": {
+        "AnotherInstanceIsRunning": {
+          "MultiInstance": "Un'altra istanza di Volume Control utilizza il file di configurazione che si trova a '${PATH}'!",
+          "SingleInstance": "È già in esecuzione un'altra istanza di Volume Control!"
+        },
+        "UpdatePrompt": {
+          "DontShowInFutureMsg": "In futuro non verranno visualizzate le richieste di aggiornamento .",
+          "NewVersionAvailableMessage": "È disponibile una nuova versione di Volume Control!\nVersione attuale:  ${CURRENT_VERSION}\nVersione aggiornata:   ${LATEST_VERSION}",
+          "NewVersionAvailableOptions_AutoUpdate": "Fai clic su 'Sì' per installare la versione più recente.\nFai clic su 'No' se non vuoi aggiornare adesso.\nFai clic su 'Annulla' per annullare queste richieste.",
+          "NewVersionAvailableOptions_OpenBrowser": "Seleziona 'Sì' per andare alla pagina di download.\nSeleziona 'No' se non vuoi aggiornare ora.\nSeleziona 'Annulla' per disabilitare questa richiesta.",
+          "DownloadFailed": {
+            "Caption": "Download fallito",
+            "Message": "Si è verificato un errore durante il download del programma di installazione, per altre info controlla il registro eventi."
+          },
+          "StartFailed": {
+            "Caption": "Avvio instalalzione fallito",
+            "Message": "Il programma di installazione è stato scaricato correttamnte ma è impossibile avviare il programma di installazione.\nLe autorizzazioni di sistema potrebbero non consentire l'esecuzione di applicazioni dalla cartella dei download.\n\nDovrai avviare il programma di installazione manualmente."
+          }
+        },
+        "ResetHotkeys": {
+          "Message": "Sei sicuro di voler ripristinare tutti i tasti di scelta rapida ai valori predefiniti?\n\nL'operazione non può essere annullata!",
+          "Caption": "Ripristino tasti rapidi"
+        },
+        "RemoveHotkey": {
+          "Message": "Sei sicuro di voler eliminare il tasto scelta rapida ${ID}?\n\n- 'Sì' elimina il tasto scelta rapida.\n- 'No' non elimina il tasto scelta rapida.\n- 'Annulla' disabilita queste richieste di conferma in futuro (non elimina il tasto di scelta rapida).\n",
+          "Caption": "Conferma rimozione"
+        },
+        "MultiInstanceChanged": {
+          "Message": "Le modifiche all'impostazione 'Multi istanza' avranno effetto dopo il riavvio dell'applicazione.\n\nVuoi riavviare l'applicazione adesso?",
+          "Caption": "È necessario il riavvio dell'applicazione"
+        }
+      },
+  
+      "NotifyIcon": {
+        "BringToFront": "Porta in primo piano",
+        "Hide": "Nascondi",
+        "Show": "Visualizza",
+        "OpenLocation": "Apri percorso",
+        "OpenAppData": "Apri AppData",
+        "Close": "Chiudi"
+      }
+    },
+  
+    "Enums": {
+      "ENotificationViewMode": {
+        "ControlBar": "Barra controllo",
+        "SelectedItemOnly": "Solo elementi selezionati",
+        "AllItems": "Tutti gli elementi"
+      },
+      "EFriendlyKey": {
+        "None": { "Italiano (Italian)": "Nessuno" },
+        "Cancel": { "Italiano (Italian)": "Annulla" },
+        "Backspace": { "Italiano (Italian)": "Backspace" },
+        "Tab": { "Italiano (Italian)": "Tabulazione" },
+        "Clear": { "Italiano (Italian)": "Azzera" },
+        "Enter": { "Italiano (Italian)": "Invio" },
+        "PauseBreak": { "Italiano (Italian)": "Pausa" },
+        "CapsLock": { "Italiano (Italian)": "BloccoMiausc" },
+        "Escape": { "Italiano (Italian)": "Escape" },
+        "Space": { "Italiano (Italian)": "Spazio" },
+        "PageUp": { "Italiano (Italian)": "PagSu" },
+        "PageDown": { "Italiano (Italian)": "PagGiù" },
+        "End": { "Italiano (Italian)": "Fine" },
+        "Home": { "Italiano (Italian)": "Home" },
+        "LeftArrow": { "Italiano (Italian)": "FrecciaSin" },
+        "UpArrow": { "Italiano (Italian)": "FrecciaSu" },
+        "RightArrow": { "Italiano (Italian)": "FrecciaDes" },
+        "DownArrow": { "Italiano (Italian)": "FrecciaGiù" },
+        "Select": { "Italiano (Italian)": "Seleziona" },
+        "Print": { "Italiano (Italian)": "Stampa" },
+        "Execute": { "Italiano (Italian)": "Esegui" },
+        "PrintScreen": { "Italiano (Italian)": "StpSchermo" },
+        "Insert": { "Italiano (Italian)": "Inserisci" },
+        "Delete": { "Italiano (Italian)": "Elimina" },
+        "Help": { "Italiano (Italian)": "Aiuto" },
+        "D0": { "Italiano (Italian)": "0" },
+        "D1": { "Italiano (Italian)": "1" },
+        "D2": { "Italiano (Italian)": "2" },
+        "D3": { "Italiano (Italian)": "3" },
+        "D4": { "Italiano (Italian)": "4" },
+        "D5": { "Italiano (Italian)": "5" },
+        "D6": { "Italiano (Italian)": "6" },
+        "D7": { "Italiano (Italian)": "7" },
+        "D8": { "Italiano (Italian)": "8" },
+        "D9": { "Italiano (Italian)": "9" },
+        "A": { "Italiano (Italian)": "A" },
+        "B": { "Italiano (Italian)": "B" },
+        "C": { "Italiano (Italian)": "C" },
+        "D": { "Italiano (Italian)": "D" },
+        "E": { "Italiano (Italian)": "E" },
+        "F": { "Italiano (Italian)": "F" },
+        "G": { "Italiano (Italian)": "G" },
+        "H": { "Italiano (Italian)": "H" },
+        "I": { "Italiano (Italian)": "I" },
+        "J": { "Italiano (Italian)": "J" },
+        "K": { "Italiano (Italian)": "K" },
+        "L": { "Italiano (Italian)": "L" },
+        "M": { "Italiano (Italian)": "M" },
+        "N": { "Italiano (Italian)": "N" },
+        "O": { "Italiano (Italian)": "O" },
+        "P": { "Italiano (Italian)": "P" },
+        "Q": { "Italiano (Italian)": "Q" },
+        "R": { "Italiano (Italian)": "R" },
+        "S": { "Italiano (Italian)": "S" },
+        "T": { "Italiano (Italian)": "T" },
+        "U": { "Italiano (Italian)": "U" },
+        "V": { "Italiano (Italian)": "V" },
+        "W": { "Italiano (Italian)": "W" },
+        "X": { "Italiano (Italian)": "X" },
+        "Y": { "Italiano (Italian)": "Y" },
+        "Z": { "Italiano (Italian)": "Z" },
+        "Apps": { "Italiano (Italian)": "App" },
+        "Sleep": { "Italiano (Italian)": "Sleep" },
+        "NumPad0": { "Italiano (Italian)": "0 (tastnum)" },
+        "NumPad1": { "Italiano (Italian)": "1 (tastnum)" },
+        "NumPad2": { "Italiano (Italian)": "2 (tastnum)" },
+        "NumPad3": { "Italiano (Italian)": "3 (tastnum)" },
+        "NumPad4": { "Italiano (Italian)": "4 (tastnum)" },
+        "NumPad5": { "Italiano (Italian)": "5 (tastnum)" },
+        "NumPad6": { "Italiano (Italian)": "6 (tastnum)" },
+        "NumPad7": { "Italiano (Italian)": "7 (tastnum)" },
+        "NumPad8": { "Italiano (Italian)": "8 (tastnum)" },
+        "NumPad9": { "Italiano (Italian)": "9 (tastnum)" },
+        "NumPadMultiply": { "Italiano (Italian)": "* (tastnum)" },
+        "NumPadAdd": { "Italiano (Italian)": "+ (tastnum)" },
+        "Separator": { "Italiano (Italian)": "Separatore" },
+        "NumPadSubtract": { "Italiano (Italian)": "- (tastnum)" },
+        "NumPadDecimal": { "Italiano (Italian)": ". (tastnum)" },
+        "NumPadDivide": { "Italiano (Italian)": "/ (tastnum)" },
+        "F1": { "Italiano (Italian)": "F1" },
+        "F2": { "Italiano (Italian)": "F2" },
+        "F3": { "Italiano (Italian)": "F3" },
+        "F4": { "Italiano (Italian)": "F4" },
+        "F5": { "Italiano (Italian)": "F5" },
+        "F6": { "Italiano (Italian)": "F6" },
+        "F7": { "Italiano (Italian)": "F7" },
+        "F8": { "Italiano (Italian)": "F8" },
+        "F9": { "Italiano (Italian)": "F9" },
+        "F10": { "Italiano (Italian)": "F10" },
+        "F11": { "Italiano (Italian)": "F11" },
+        "F12": { "Italiano (Italian)": "F12" },
+        "F13": { "Italiano (Italian)": "F13" },
+        "F14": { "Italiano (Italian)": "F14" },
+        "F15": { "Italiano (Italian)": "F15" },
+        "F16": { "Italiano (Italian)": "F16" },
+        "F17": { "Italiano (Italian)": "F17" },
+        "F18": { "Italiano (Italian)": "F18" },
+        "F19": { "Italiano (Italian)": "F19" },
+        "F20": { "Italiano (Italian)": "F20" },
+        "F21": { "Italiano (Italian)": "F21" },
+        "F22": { "Italiano (Italian)": "F22" },
+        "F23": { "Italiano (Italian)": "F23" },
+        "F24": { "Italiano (Italian)": "F24" },
+        "NumLock": { "Italiano (Italian)": "BloccoNum" },
+        "ScrollLock": { "Italiano (Italian)": "BloccoScorr" },
+        "BrowserBack": { "Italiano (Italian)": "Indietro (Browser)" },
+        "BrowserForward": { "Italiano (Italian)": "Avanti(Browser)" },
+        "BrowserRefresh": { "Italiano (Italian)": "Aggiorna (Browser)" },
+        "BrowserStop": { "Italiano (Italian)": "Stop (Browser)" },
+        "BrowserSearch": { "Italiano (Italian)": "Cerca(Browser)" },
+        "BrowserFavorites": { "Italiano (Italian)": "Preferiti (Browser)" },
+        "BrowserHome": { "Italiano (Italian)": "Home (Browser)" },
+        "VolumeMute": { "Italiano (Italian)": "Audio off (Browser)" },
+        "VolumeDown": { "Italiano (Italian)": "Volume -" },
+        "VolumeUp": { "Italiano (Italian)": "Volume +" },
+        "MediaNextTrack": { "Italiano (Italian)": "Traccia successiva media" },
+        "MediaPreviousTrack": { "Italiano (Italian)": "Traccia precedente media" },
+        "MediaStop": { "Italiano (Italian)": "Stop media" },
+        "MediaPlayPause": { "Italiano (Italian)": "Pausa riproduzione media" },
+        "LaunchMail": { "Italiano (Italian)": "Esegui programma mail" },
+        "SelectMedia": { "Italiano (Italian)": "Seleziona media" },
+        "LaunchApplication1": { "Italiano (Italian)": "Esegui applicazione1" },
+        "LaunchApplication2": { "Italiano (Italian)": "Esegui applicazione2" },
+        "Semicolon": { "Italiano (Italian)": "Punto e virgola" },
+        "Equals": { "Italiano (Italian)": "Uguale" },
+        "Comma": { "Italiano (Italian)": "Virgola" },
+        "Dash": { "Italiano (Italian)": "Trattino" },
+        "Period": { "Italiano (Italian)": "Punto" },
+        "ForwardSlash": { "Italiano (Italian)": "Slash" },
+        "Grave": { "Italiano (Italian)": "Grave" },
+        "OpenBracket": { "Italiano (Italian)": "ParenetsiAperta" },
+        "BackSlash": { "Italiano (Italian)": "Backslash" },
+        "CloseBracket": { "Italiano (Italian)": "ParentesiChiusa" },
+        "Quote": { "Italiano (Italian)": "Virgolette" },
+        "Oem8": { "Italiano (Italian)": "Oem8" },
+        "OemBackslash": { "Italiano (Italian)": "BackslashOem" },
+        "ImeProcess": { "Italiano (Italian)": "ImeProcess" },
+        "Attn": { "Italiano (Italian)": "Attn" },
+        "CrSel": { "Italiano (Italian)": "CrSel" },
+        "ExSel": { "Italiano (Italian)": "ExSel" },
+        "EraseEof": { "Italiano (Italian)": "EliminaEof" },
+        "Play": { "Italiano (Italian)": "Riproduci" },
+        "Zoom": { "Italiano (Italian)": "Zoom" },
+        "Pa1": { "Italiano (Italian)": "Pa1" },
+        "OemClear": { "Italiano (Italian)": "AzzeraOem" },
+        "ImeKanaMode": { "Italiano (Italian)": "ImeModoKana" },
+        "ImeJunjaMode": { "Italiano (Italian)": "ImeModoJunja" },
+        "ImeFinalMode": { "Italiano (Italian)": "ImeModoFinal" },
+        "ImeHanjaMode": { "Italiano (Italian)": "ImeModoHanja" },
+        "ImeConvert": { "Italiano (Italian)": "ImeConvert" },
+        "ImeNonConvert": { "Italiano (Italian)": "ImeNonConvert" },
+        "ImeAccept": { "Italiano (Italian)": "ImeAccetta" },
+        "ImeModeChange": { "Italiano (Italian)": "ImemCambiaModo" }
+  
+      }
+    },
+  
+    "DefaultHotkeyNames": {
+      "Volume Up": "Volume +",
+      "Volume Down": "Volume -",
+      "Toggle Mute": "Audio OFF/ON",
+      "Next Session": "Sessione successiva",
+      "Previous Session": "Sessione precedente",
+      "Un/Lock Session": {
+        "Italiano (Italian)": "Sblocca/blocca sessione"
+      },
+      "Toggle Selected": "Selezionati ON/OFF"
+    }
+  }

--- a/VolumeControl/Localization/es.loc.json
+++ b/VolumeControl/Localization/es.loc.json
@@ -1,576 +1,575 @@
 {
-    "$LanguageName": "Español (Spanish)",
-  
-    "VolumeControl": {
-      "MainWindow": {
-        "CaptionBar": {
-          "Title": {
-            "Content": "Volume Control"          
+  "$LanguageName": "Español (Spain)",
+
+  "VolumeControl": {
+    "MainWindow": {
+      "CaptionBar": {
+        "Title": {
+          "Content": "Volume Control"
+        },
+        "BugReport": {
+          "Content": "✏",
+          "Tooltip": "Informar de un error"
+        }
+      },
+      "Mixer": {
+        "TabHeader": "Mezclador",
+        "TargetBox": {
+          "Watermark": "ID del proceso o nombre",
+          "LockTarget": "Bloquear"
+        },
+        "MixerGrid": {
+          "Selected": {
+            "Header": {
+              "Tooltip": "(De)seleccionar todas las sesiones."
+            }
           },
-          "BugReport": {
-            "Content": "✏",
-            "Tooltip": "Informar de un error"
+          "PID": {
+            "Header": "ID Proceso"
+          },
+          "Name": {
+            "Header": "Nombre"
+          },
+          "Mute": {
+            "Header": "Silenciar"
+          },
+          "Volume": {
+            "Header": "Volumen"
+          },
+          "Select": {
+            "Button": "Seleccionar"
+          }
+        }
+      },
+      "Hotkeys": {
+        "TabHeader": "Atajos",
+        "ControlRow": {
+          "VolumeStep": {
+            "Content": "Intervalo de volumen",
+            "Tooltip": "Este número corresponde a la cantidad de volumen que se resta o se suma cada vez que presionas las teclas de subir o bajar volumen."
+          },
+          "ResetToDefault": {
+            "Content": "Restablecer atajos",
+            "Tooltip": "Restablecer la configuración actual a los valores predeterminados."
           }
         },
-        "Mixer": {
-          "TabHeader": "Mixer",
-          "TargetBox": {
-            "Watermark": "ID del proceso o nombre",
-            "LockTarget": "Bloquear"
+        "HotkeyGrid": {
+          "Active": {
+            "Header": {
+              "Tooltip": "(Des)activar todos los atajos."
+            }
           },
-          "MixerGrid": {
-            "Selected": {
-              "Header": {
-                "Tooltip": "(De)seleccionar todo"
-              }
+          "Name": {
+            "Header": "Nombre"
+          },
+          "Key": {
+            "Header": "Tecla",
+            "KeySelector": {
+              "Content": "🖮",
+              "Tooltip": "Haz clic y mantén el botón presionado, luego pulsa cualquier tecla para seleccionarla sin buscarla en la lista."
+            }
+          },
+          "Alt": {
+            "Header": "Alt"
+          },
+          "Ctrl": {
+            "Header": "Ctrl"
+          },
+          "Shift": {
+            "Header": "Mayús"
+          },
+          "Windows": {
+            "Header": "Win"
+          },
+          "Action": {
+            "Header": "Acción"
+          }
+        },
+        "CreateNewHotkeyButton": {
+          "Content": "Crear un atajo",
+          "Tooltip": "Crear un atajo vacío."
+        }
+      },
+      "Settings": {
+        "TabHeader": "Configuración",
+        "Language": {
+          "Header": "Idioma",
+          "CustomLocations": "Ubicación personalizada",
+          "Reload": {
+            "Content": "Actualizar",
+            "Tooltip": "Actualizar todos los archivos de configuración de idioma desde el disco duro."
+          }
+        },
+        "Audio": {
+          "Header": "Audio",
+          "AdditionalSettings": {
+            "Header": {
+              "Content": "Configuración adicional",
+              "Tooltip": {}
             },
-            "PID": {
-              "Header": "ID Proceso"
+            "ShowPeakMeters": {
+              "Content": "Mostrar medidor de niveles de audio",
+              "Tooltip": "(Des)activar la visualización de los niveles de audio en las notificaciones."
+            },
+            "UpdateInterval": {
+              "Content": "Frecuencia de actualizacion",
+              "Tooltip": "La cantidad de tiempo, en milisegundos, entre cada actualización del medidor de volumen."
+            },
+            "EnableDeviceControl": {
+              "Content": "Mostrar controles de los dispositivos",
+              "Tooltip": "(Des)activar la visibilidad de los controles de volumen y silencio en la sección de dispositivos."
+            },
+            "HiddenSessions": {
+              "Content": "Sesiones ocultas",
+              "Tooltip": {}
+            }
+          },
+          "DeviceGrid": {
+            "Enabled": {
+              "Header": {
+                "Tooltip": "(De)seleccionar todos los dispositivos."
+              },
+              "Tooltip": "Puedes incluir o excluir dispositivos específicos desde aquí."
             },
             "Name": {
-              "Header": "Nombre"
+              "Header": "Nombre del dispositivo"
+            },
+            "Interface": {
+              "Header": "Nombre de la interfaz"
             },
             "Mute": {
               "Header": "Silenciar"
             },
             "Volume": {
               "Header": "Volumen"
-            },
-            "Select": {
-              "Button": "Seleccionar"
             }
           }
         },
-        "Hotkeys": {
-          "TabHeader": "Atajos",
-          "ControlRow": {
-            "VolumeStep": {
-              "Content": "Intervalo de volumen",
-              "Tooltip": "Este número corresponde a la cantidad de volumen que se resta o se suma cada vez que presionas las teclas de subir o bajar volumen."
-            },
-            "ResetToDefault": {
-              "Content": "Ripristina predefiniti",
-              "Tooltip": "Ripristina tutti i tasti scelta rapida alle impostazioni predefinite."
-            }
-          },
-          "HotkeyGrid": {
-            "Active": {
-              "Header": {
-                "Tooltip": "Questo (annulla) la registrazione di tutti i tasti di scelta rapida nell'elenco."
-              }
-            },
-            "Name": {
-              "Header": "Nome"
-            },
-            "Key": {
-              "Header": "Chiave",
-              "KeySelector": {
-                "Content": "🖮",
-                "Tooltip": "Fai clic e tieni premuto con il mouse, quindi premi un tasto per selezionarlo.\nI tasti scelta rapida registrati possono comunque essere attivati."
-              }
-            },
-            "Alt": {
-              "Header": "Alt"
-            },
-            "Ctrl": {
-              "Header": "Ctrl"
-            },
-            "Shift": {
-              "Header": "Maiusc"
-            },
-            "Windows": {
-              "Header": "Win"
-            },
-            "Action": {
-              "Header": "Azione"
-            }
-          },
-          "CreateNewHotkeyButton": {
-            "Content": "Crea nuovo tasto rapido",
-            "Tooltip": "Crea un nuovo tasto di scelta rapida vuoto."
-          }
-        },
-        "Settings": {
-          "TabHeader": "Impostazioni",
-          "Language": {
-            "Header": "Lingua",
-            "CustomLocations": "Percorso personalizzato",
-            "Reload": {
-              "Content": "Ricarica",
-              "Tooltip": "Ricarica tutti i file di configurazione della lingua dal disco."
-            }
-          },
-          "Audio": {
-            "Header": "Audio",
-            "AdditionalSettings": {
-              "Header": {
-                "Content": "Impostazioni aggiuntive",
-                "Tooltip": {}
-              },
-              "ShowPeakMeters": {
-                "Content": "Visualizza misuratori picco",
-                "Tooltip": "Attiva/disattiva misuratori picco audio nel mixer."
-              },
-              "UpdateInterval": {
-                "Content": "Intervallo aggiornamento",
-                "Tooltip": "La quantità di tempo, in millisecondi, tra ogni aggiornamento dei misuratori picco nel mixer."
-              },
-              "EnableDeviceControl": {
-                "Content": "Visualizza controlli dispositivo",
-                "Tooltip": "Attiva/disattiva visualizzazione controlli volume e muto nella sezione Dispositivi audio."
-              },
-              "HiddenSessions": {
-                "Content": "Sessioni nascoste",
-                "Tooltip": {}
-              }
-            },
-            "DeviceGrid": {
-              "Enabled": {
-                "Header": {
-                  "Tooltip": "Qui puoi includere o escludere dispositivi audio specifici."
-                },
-                "Tooltip": "Qui puoi includere o escludere dispositivi specifici."
-              },
-              "Name": {
-                "Header": "Nome dispositivo"
-              },
-              "Interface": {
-                "Header": "Nome interfaccia"
-              },
-              "Mute": {
-                "Header": "Audio off"
-              },
-              "Volume": {
-                "Header": "Volume"
-              }
-            }
-          },
-          "Notifications": {
-            "Header": "Notifiche",
-            "AdditionalSettings": {
-              "Header": {
-                "Content": "Impostazioni aggiuntive",
-                "Tooltip": {}
-              },
-              "ResetPosition": {
-                "Content": "Ripristina Posizione",
-                "Tooltip": "Reimpostare la posizione della notifica dell'elenco nel caso in cui scompaia dal riquadro di visualizzazione."
-              },
-              "ForceHide": {
-                "Content": "Nascondi",
-                "Tooltip": "Forza la scomparsa della finestra di notifica."
-              },
-              "HiddenSessions": {
-                "Content": "Nascondi sessioni",
-                "Tooltip": {}
-              }
-            },
-            "Enable": {
-              "Content": "Abilita",
-              "Tooltip": "Attiva/disattiva la visualizzazione delle notifiche quando si cambia la sessione destinazione."
-            },
-            "OnVolumeChange": {
-              "Content": "Al cambio di volume",
-              "Tooltip": "Quando questa opzione è selezionata, vengono visualizzate anche le notifiche quando viene modificato il livello del volume destinazione."
-            },
-            "Timeout": {
-              "Content": "Timeout",
-              "Tooltip": "La quantità di tempo in millisecondi durante la quale le notifiche rimarranno visibili dopo essere state attivate."
-            },
-            "SessionListNotificationConfig": {
-              "Header": {
-                "Content": "Opzioni notifica sessioni",
-                "Tooltip": {}
-              }
-            },
-            "DeviceListNotificationConfig": {
-              "Header": {
-                "Content": "Opzioni notifica dispositivo",
-                "Tooltip": {}
-              }
-            },
-            "ColorPicker": {
-              "Background": {
-                "Tooltip": "Imposta il colore di sfondo della finestra di notifica."
-              },
-              "Foreground": {
-                "Tooltip": "Imposta il colore del testo della finestra di notifica."
-              },
-              "LockedAccent": {
-                "Tooltip": "Imposta il colore di evidenziazione della finestra di notifica quando la selezione è bloccata."
-              },
-              "UnlockedAccent": {
-                "Tooltip": "Imposta il colore di evidenziazione della finestra di notifica quando la selezione è sbloccata."
-              }
-            },
-            "CornerRadius": {
-              "Content": "Raggio angolo:",
-              "Tooltip": "Il raggio degli angoli della finestra di notifica.\nInizia dall'angolo in alto a sinistra e procede in senso orario."
-            }
-          },
-          "Log": {
-            "Header": "Registrazione eventi",
-            "Enable": {
-              "Content": "Abilita"
-            },
-            "Filter": {
-              "Text": "Filtro"
-            },
-            "Path": {
-              "Tooltip": "Specifica il percorso e il nome del file registro.\nI percorsi relativi sono relativi alla posizione dell'eseguibile.",
-              "WatermarkText": "percorso file registro eventi"
-            },
-            "OpenButton": {
-              "Content": "Apri",
-              "Tooltip": "Apri il file registro eventi nell'applicazione predefinita."
-            }
-          },
-          "Application": {
-            "Header": "Applicazione",
-            "RunAtStartup": {
-              "Content": "Esegui all'avvio del sistema",
-              "Tooltip": "Quando abilitato, il controllo del volume verrà eseguito all'accesso del sistema.",
-              "AltTooltip": "Un'altra istanza di Controllo volume è impostata per essere eseguita all'avvio.\nLa modifica di questo lo sostituirà."
-            },
-            "StartMinimized": {
-              "Content": "Avvia minimizzato",
-              "Tooltip": "Quando abilitato, il controllo del volume verrà minimizzato dopo l'esecuzione."
-            },
-            "MultiInstance": {
-              "Content": "Multi-Istanza",
-              "Tooltip": "Consenti l'esecuzione simultanea di più istanze di Volume Control, a condizione che utilizzino un file di configurazione diverso."
-            },
-            "ShowInTaskbar": {
-              "Content": "Visualizza nella barra sistema",
-              "Tooltip": {}
-            },
-            "AlwaysOnTop": {
-              "Content": "Sempre in primo piano",
-              "Tooltip": {}
-            },
-            "ShowIcons": {
-              "Content": "Visualizza icone",
-              "Tooltip": "Quando abilitato, il programma tenterà di visualizzare l'icona associata ai dispositivi audio e alle sessioni (durante l'esecuzione come utente potrebbero mancare alcune icone )."
-            },
-            "KeepRelativePosition": {
-              "Content": "Mantieni posizione relativa",
-              "Tooltip": "Quando la dimensione della finestra cambia mantieni la finestra principale nella stessa posizione rispetto all'angolo dello schermo più vicino "
-            },
-            "RestorePosition": {
-              "Content": "Ripristina posizione",
-              "Tooltip": "Ripristina la posizione precedente della finestra principale all'avvio del programma."
-            },
-            "EnableInputDevices": {
-              "Content": "Supporto ingresso audio",
-              "Tooltip": "Abilita il supporto per dispositivi di acquisizione e sessioni che registrano audio."
-            }
-          },
-          "Updates": {
-            "Header": "Aggiornamenti",
-            "CheckNow": {
-              "Content": "Controlla",
-              "Tooltip": "Controlla manualmente la disponibilità di nuove versioni di Volume Control."
-            },
-            "OnStartup": {
-              "Content": "All'avvio",
-              "Tooltip": "All'avvio verifica disponibilità aggiornamenti del programma."
-            },
-            "ShowPrompt": {
-              "Content": "Visualizza prompt",
-              "Tooltip": "Quando questa opzione è selezionata, verrà richiesto di aggiornare sotto forma di una finestra di messaggio; altrimenti vedrai un'icona nell'angolo in alto a destra."
-            }
-          }
-        },
-        "About": {
-          "TabHeader": "Info sul programma",
-          "ReportABug": {
-            "Content": "Segnala un bug",
-            "Tooltip": "Facci sapere se qualcosa non funziona correttamente"
-          },
-          "OpenWebsite": {
-            "Content": "Sito web ufficiale",
-            "Tooltip": "Apri il sito web ufficiale di Volume Control nel browser predefinito"
-          },
-          "ShowDebugInfo": {
+        "Notifications": {
+          "Header": "Notificaciones",
+          "AdditionalSettings": {
             "Header": {
-              "Content": "Visualizza informazioni di debug",
+              "Content": "Configuración adicional",
               "Tooltip": {}
             },
-            "ConfigPath": {
-              "Content": {
-                "Italiano (Italian)": ""
-              },
-              "Tooltip": {
-                "Italiano (Italian)": ""
-              }
+            "ResetPosition": {
+              "Content": "Restablecer la posición de las notificaciones",
+              "Tooltip": "Restablecer la posición de las notificaciones si desaparecen."
+            },
+            "ForceHide": {
+              "Content": "Ocultar",
+              "Tooltip": "Forzar la desaparición de la ventana de notificaciones."
+            },
+            "HiddenSessions": {
+              "Content": "Sesiones ocultas",
+              "Tooltip": {}
             }
+          },
+          "Enable": {
+            "Content": "Habilitar",
+            "Tooltip": "(Des)habilitar las notificaciones de las sesiones."
+          },
+          "OnVolumeChange": {
+            "Content": "Al modificar el volumen",
+            "Tooltip": "Mostrar notificaciones al cambiar el volumen o al (de)silenciar."
+          },
+          "Timeout": {
+            "Content": "Tiempo de espera",
+            "Tooltip": "La cantidad de tiempo, en milisegundos, que las notificaciones permanecerán visibles tras ser activadas."
+          },
+          "SessionListNotificationConfig": {
+            "Header": {
+              "Content": "Ajustes de notificación de sesiones",
+              "Tooltip": {}
+            }
+          },
+          "DeviceListNotificationConfig": {
+            "Header": {
+              "Content": "Ajustes de notificación de dispositivos",
+              "Tooltip": {}
+            }
+          },
+          "ColorPicker": {
+            "Background": {
+              "Tooltip": "Establece el color de fondo de la ventana de notificaciones."
+            },
+            "Foreground": {
+              "Tooltip": "Establece el color del texto de la ventana de notificaciones."
+            },
+            "LockedAccent": {
+              "Tooltip": "Establece el color de énfasis de la ventana de notificaciones cuando la selección está bloqueada."
+            },
+            "UnlockedAccent": {
+              "Tooltip": "Establece el color de énfasis de la ventana de notificaciones cuando la selección está desbloqueada."
+            }
+          },
+          "CornerRadius": {
+            "Content": "Radio de las esquinas:",
+            "Tooltip": "Radio de las esquinas de la ventana de notificaciones, empezando en la esquina superior izquierda y avanzando en sentido horario."
           }
-        }
-      },
-  
-      "ListNotification": {
-        "Options": {
-          "Header": "Opzioni",
-          "ShowControls": {
-            "Content": "Visualizza controlli",
-            "Tooltip": "Attiva/disattiva visualizzazione controlli avanzati accanto agli elementi dell'elenco."
+        },
+        "Log": {
+          "Header": "Registro de eventos",
+          "Enable": {
+            "Content": "Habilitar"
           },
-          "DragRequiresAlt": {
-            "Content": "Trascina richiede uso 'Alt'",
-            "Tooltip": "Quando selezionato, il tasto ALT deve essere tenuto premuto per poter trascinare la finestra di notifica con il mouse."
+          "Filter": {
+            "Text": "Filtros"
           },
-          "SavePosition": {
-            "Content": "Salva posizione",
+          "Path": {
+            "Tooltip": "Especifica la ubicación y el nombre del archivo de registro. Las rutas relativas son relativas a la ubicación del archivo ejecutable.",
+            "WatermarkText": "Ruta al archivo de registro"
+          },
+          "OpenButton": {
+            "Content": "Abrir",
+            "Tooltip": "Abrir el archivo de registro en la aplicación predeterminada."
+          }
+        },
+        "Application": {
+          "Header": "Aplicación",
+          "RunAtStartup": {
+            "Content": "Ejecutar al iniciar",
+            "Tooltip": "Cuando está habilitado, Volume Control se iniciará al iniciar sesión.",
+            "AltTooltip": "Otra instancia de Volume Control está configurada para ejecutarse al inicio. Cambiar esto la reemplazará."
+          },
+          "StartMinimized": {
+            "Content": "Iniciar minimizado",
+            "Tooltip": "Cuando está habilitado, Volume Control se minimizará al iniciarse."
+          },
+          "MultiInstance": {
+            "Content": "Multi-instancias",
+            "Tooltip": "Permite que varias instancias de Volume Control se ejecuten al mismo tiempo, siempre que utilicen un archivo de configuración diferente."
+          },
+          "ShowInTaskbar": {
+            "Content": "Mostrar en la barra de tareas",
             "Tooltip": {}
           },
-          "DoFadeIn": {
-            "Content": "Dissolvenza iniziale",
-            "Tooltip": "Se selezionata, la finestra di notifica visualizza un'animazione dissolvenza iniziale invece di apparire istantaneamente."
+          "AlwaysOnTop": {
+            "Content": "Siempre en primer plano",
+            "Tooltip": {}
           },
-          "FadeInDuration": {
-            "Tooltip": "Specifica la durata in millisecondi dell'animazione dissolvenza iniziale."
+          "ShowIcons": {
+            "Content": "Mostrar iconos",
+            "Tooltip": "(Des)habilitar la visualización de los iconos de dispositivos y sesiones."
           },
-          "DoFadeOut": {
-            "Content": "Dissolvenza finale",
-            "Tooltip": "Se selezionata, la finestra di notifica visualizza un'animazione dissolvenza finale invece di scomparire all'istante."
+          "KeepRelativePosition": {
+            "Content": "Mantener posición relativa",
+            "Tooltip": "Mantener la ventana principal en la misma posición relativa a la esquina de la pantalla más cercana cuando su tamaño cambia."
           },
-          "FadeOutDuration": {
-            "Tooltip": "Specifica la durata in millisecondi dell'animazione dissolvenza finale."
+          "RestorePosition": {
+            "Content": "Restaurar posición",
+            "Tooltip": "Restaurar la posición anterior de la ventana principal al iniciar el programa."
+          },
+          "EnableInputDevices": {
+            "Content": "Soporte de entrada de audio",
+            "Tooltip": "(Des)habilitar el soporte para dispositivos de captura y sesiones que graban audio."
+          }
+        },
+        "Updates": {
+          "Header": "Actualizaciones",
+          "CheckNow": {
+            "Content": "Comprobar ahora",
+            "Tooltip": "Comprobar manualmente si hay nuevas versiones de Volume Control."
+          },
+          "OnStartup": {
+            "Content": "Al iniciar",
+            "Tooltip": "Comprobar si hay nuevas versiones de Volume Control al iniciar."
+          },
+          "ShowPrompt": {
+            "Content": "Mostrar mensaje",
+            "Tooltip": "Si esta opción está seleccionada, se te pedirá que actualices mediante un cuadro de mensaje; de lo contrario, verás un icono en la esquina superior derecha."
           }
         }
       },
-  
-      "ActionSettingsWindow": {
-        "DataTemplateErrorTextBlock": {
-          "Tooltip": "Non è disponibile nessun ModelloDati per questo tipo di valore!"
+      "About": {
+        "TabHeader": "Acerca de",
+        "ReportABug": {
+          "Content": "Informar de un error",
+          "Tooltip": "Infórmanos si algo no está funcionando correctamente."
         },
-        "ToggleActionSetting": {
-          "Content": "Abilita",
-          "Tooltip": "Questa impostazione di azione è abilitata quando selezionata."
+        "OpenWebsite": {
+          "Content": "Sito web oficial",
+          "Tooltip": "Abrir el sitio web oficial de Volume Control en tu navegador predeterminado."
         },
-        "ActionTargetSpecifierDataTemplate": {
-          "AddTargetBox": {
-            "DefaultText": "Nome destinazione..."
-          }
-        }
-      },
-  
-      "Dialogs": {
-        "AnotherInstanceIsRunning": {
-          "MultiInstance": "Un'altra istanza di Volume Control utilizza il file di configurazione che si trova a '${PATH}'!",
-          "SingleInstance": "È già in esecuzione un'altra istanza di Volume Control!"
-        },
-        "UpdatePrompt": {
-          "DontShowInFutureMsg": "In futuro non verranno visualizzate le richieste di aggiornamento .",
-          "NewVersionAvailableMessage": "È disponibile una nuova versione di Volume Control!\nVersione attuale:  ${CURRENT_VERSION}\nVersione aggiornata:   ${LATEST_VERSION}",
-          "NewVersionAvailableOptions_AutoUpdate": "Fai clic su 'Sì' per installare la versione più recente.\nFai clic su 'No' se non vuoi aggiornare adesso.\nFai clic su 'Annulla' per annullare queste richieste.",
-          "NewVersionAvailableOptions_OpenBrowser": "Seleziona 'Sì' per andare alla pagina di download.\nSeleziona 'No' se non vuoi aggiornare ora.\nSeleziona 'Annulla' per disabilitare questa richiesta.",
-          "DownloadFailed": {
-            "Caption": "Download fallito",
-            "Message": "Si è verificato un errore durante il download del programma di installazione, per altre info controlla il registro eventi."
+        "ShowDebugInfo": {
+          "Header": {
+            "Content": "Mostrar información de depuración",
+            "Tooltip": {}
           },
-          "StartFailed": {
-            "Caption": "Avvio instalalzione fallito",
-            "Message": "Il programma di installazione è stato scaricato correttamnte ma è impossibile avviare il programma di installazione.\nLe autorizzazioni di sistema potrebbero non consentire l'esecuzione di applicazioni dalla cartella dei download.\n\nDovrai avviare il programma di installazione manualmente."
+          "ConfigPath": {
+            "Content": {
+              "Español (Spain)": ""
+            },
+            "Tooltip": {
+              "Español (Spain)": ""
+            }
           }
-        },
-        "ResetHotkeys": {
-          "Message": "Sei sicuro di voler ripristinare tutti i tasti di scelta rapida ai valori predefiniti?\n\nL'operazione non può essere annullata!",
-          "Caption": "Ripristino tasti rapidi"
-        },
-        "RemoveHotkey": {
-          "Message": "Sei sicuro di voler eliminare il tasto scelta rapida ${ID}?\n\n- 'Sì' elimina il tasto scelta rapida.\n- 'No' non elimina il tasto scelta rapida.\n- 'Annulla' disabilita queste richieste di conferma in futuro (non elimina il tasto di scelta rapida).\n",
-          "Caption": "Conferma rimozione"
-        },
-        "MultiInstanceChanged": {
-          "Message": "Le modifiche all'impostazione 'Multi istanza' avranno effetto dopo il riavvio dell'applicazione.\n\nVuoi riavviare l'applicazione adesso?",
-          "Caption": "È necessario il riavvio dell'applicazione"
         }
-      },
-  
-      "NotifyIcon": {
-        "BringToFront": "Porta in primo piano",
-        "Hide": "Nascondi",
-        "Show": "Visualizza",
-        "OpenLocation": "Apri percorso",
-        "OpenAppData": "Apri AppData",
-        "Close": "Chiudi"
       }
     },
-  
-    "Enums": {
-      "ENotificationViewMode": {
-        "ControlBar": "Barra controllo",
-        "SelectedItemOnly": "Solo elementi selezionati",
-        "AllItems": "Tutti gli elementi"
-      },
-      "EFriendlyKey": {
-        "None": { "Italiano (Italian)": "Nessuno" },
-        "Cancel": { "Italiano (Italian)": "Annulla" },
-        "Backspace": { "Italiano (Italian)": "Backspace" },
-        "Tab": { "Italiano (Italian)": "Tabulazione" },
-        "Clear": { "Italiano (Italian)": "Azzera" },
-        "Enter": { "Italiano (Italian)": "Invio" },
-        "PauseBreak": { "Italiano (Italian)": "Pausa" },
-        "CapsLock": { "Italiano (Italian)": "BloccoMiausc" },
-        "Escape": { "Italiano (Italian)": "Escape" },
-        "Space": { "Italiano (Italian)": "Spazio" },
-        "PageUp": { "Italiano (Italian)": "PagSu" },
-        "PageDown": { "Italiano (Italian)": "PagGiù" },
-        "End": { "Italiano (Italian)": "Fine" },
-        "Home": { "Italiano (Italian)": "Home" },
-        "LeftArrow": { "Italiano (Italian)": "FrecciaSin" },
-        "UpArrow": { "Italiano (Italian)": "FrecciaSu" },
-        "RightArrow": { "Italiano (Italian)": "FrecciaDes" },
-        "DownArrow": { "Italiano (Italian)": "FrecciaGiù" },
-        "Select": { "Italiano (Italian)": "Seleziona" },
-        "Print": { "Italiano (Italian)": "Stampa" },
-        "Execute": { "Italiano (Italian)": "Esegui" },
-        "PrintScreen": { "Italiano (Italian)": "StpSchermo" },
-        "Insert": { "Italiano (Italian)": "Inserisci" },
-        "Delete": { "Italiano (Italian)": "Elimina" },
-        "Help": { "Italiano (Italian)": "Aiuto" },
-        "D0": { "Italiano (Italian)": "0" },
-        "D1": { "Italiano (Italian)": "1" },
-        "D2": { "Italiano (Italian)": "2" },
-        "D3": { "Italiano (Italian)": "3" },
-        "D4": { "Italiano (Italian)": "4" },
-        "D5": { "Italiano (Italian)": "5" },
-        "D6": { "Italiano (Italian)": "6" },
-        "D7": { "Italiano (Italian)": "7" },
-        "D8": { "Italiano (Italian)": "8" },
-        "D9": { "Italiano (Italian)": "9" },
-        "A": { "Italiano (Italian)": "A" },
-        "B": { "Italiano (Italian)": "B" },
-        "C": { "Italiano (Italian)": "C" },
-        "D": { "Italiano (Italian)": "D" },
-        "E": { "Italiano (Italian)": "E" },
-        "F": { "Italiano (Italian)": "F" },
-        "G": { "Italiano (Italian)": "G" },
-        "H": { "Italiano (Italian)": "H" },
-        "I": { "Italiano (Italian)": "I" },
-        "J": { "Italiano (Italian)": "J" },
-        "K": { "Italiano (Italian)": "K" },
-        "L": { "Italiano (Italian)": "L" },
-        "M": { "Italiano (Italian)": "M" },
-        "N": { "Italiano (Italian)": "N" },
-        "O": { "Italiano (Italian)": "O" },
-        "P": { "Italiano (Italian)": "P" },
-        "Q": { "Italiano (Italian)": "Q" },
-        "R": { "Italiano (Italian)": "R" },
-        "S": { "Italiano (Italian)": "S" },
-        "T": { "Italiano (Italian)": "T" },
-        "U": { "Italiano (Italian)": "U" },
-        "V": { "Italiano (Italian)": "V" },
-        "W": { "Italiano (Italian)": "W" },
-        "X": { "Italiano (Italian)": "X" },
-        "Y": { "Italiano (Italian)": "Y" },
-        "Z": { "Italiano (Italian)": "Z" },
-        "Apps": { "Italiano (Italian)": "App" },
-        "Sleep": { "Italiano (Italian)": "Sleep" },
-        "NumPad0": { "Italiano (Italian)": "0 (tastnum)" },
-        "NumPad1": { "Italiano (Italian)": "1 (tastnum)" },
-        "NumPad2": { "Italiano (Italian)": "2 (tastnum)" },
-        "NumPad3": { "Italiano (Italian)": "3 (tastnum)" },
-        "NumPad4": { "Italiano (Italian)": "4 (tastnum)" },
-        "NumPad5": { "Italiano (Italian)": "5 (tastnum)" },
-        "NumPad6": { "Italiano (Italian)": "6 (tastnum)" },
-        "NumPad7": { "Italiano (Italian)": "7 (tastnum)" },
-        "NumPad8": { "Italiano (Italian)": "8 (tastnum)" },
-        "NumPad9": { "Italiano (Italian)": "9 (tastnum)" },
-        "NumPadMultiply": { "Italiano (Italian)": "* (tastnum)" },
-        "NumPadAdd": { "Italiano (Italian)": "+ (tastnum)" },
-        "Separator": { "Italiano (Italian)": "Separatore" },
-        "NumPadSubtract": { "Italiano (Italian)": "- (tastnum)" },
-        "NumPadDecimal": { "Italiano (Italian)": ". (tastnum)" },
-        "NumPadDivide": { "Italiano (Italian)": "/ (tastnum)" },
-        "F1": { "Italiano (Italian)": "F1" },
-        "F2": { "Italiano (Italian)": "F2" },
-        "F3": { "Italiano (Italian)": "F3" },
-        "F4": { "Italiano (Italian)": "F4" },
-        "F5": { "Italiano (Italian)": "F5" },
-        "F6": { "Italiano (Italian)": "F6" },
-        "F7": { "Italiano (Italian)": "F7" },
-        "F8": { "Italiano (Italian)": "F8" },
-        "F9": { "Italiano (Italian)": "F9" },
-        "F10": { "Italiano (Italian)": "F10" },
-        "F11": { "Italiano (Italian)": "F11" },
-        "F12": { "Italiano (Italian)": "F12" },
-        "F13": { "Italiano (Italian)": "F13" },
-        "F14": { "Italiano (Italian)": "F14" },
-        "F15": { "Italiano (Italian)": "F15" },
-        "F16": { "Italiano (Italian)": "F16" },
-        "F17": { "Italiano (Italian)": "F17" },
-        "F18": { "Italiano (Italian)": "F18" },
-        "F19": { "Italiano (Italian)": "F19" },
-        "F20": { "Italiano (Italian)": "F20" },
-        "F21": { "Italiano (Italian)": "F21" },
-        "F22": { "Italiano (Italian)": "F22" },
-        "F23": { "Italiano (Italian)": "F23" },
-        "F24": { "Italiano (Italian)": "F24" },
-        "NumLock": { "Italiano (Italian)": "BloccoNum" },
-        "ScrollLock": { "Italiano (Italian)": "BloccoScorr" },
-        "BrowserBack": { "Italiano (Italian)": "Indietro (Browser)" },
-        "BrowserForward": { "Italiano (Italian)": "Avanti(Browser)" },
-        "BrowserRefresh": { "Italiano (Italian)": "Aggiorna (Browser)" },
-        "BrowserStop": { "Italiano (Italian)": "Stop (Browser)" },
-        "BrowserSearch": { "Italiano (Italian)": "Cerca(Browser)" },
-        "BrowserFavorites": { "Italiano (Italian)": "Preferiti (Browser)" },
-        "BrowserHome": { "Italiano (Italian)": "Home (Browser)" },
-        "VolumeMute": { "Italiano (Italian)": "Audio off (Browser)" },
-        "VolumeDown": { "Italiano (Italian)": "Volume -" },
-        "VolumeUp": { "Italiano (Italian)": "Volume +" },
-        "MediaNextTrack": { "Italiano (Italian)": "Traccia successiva media" },
-        "MediaPreviousTrack": { "Italiano (Italian)": "Traccia precedente media" },
-        "MediaStop": { "Italiano (Italian)": "Stop media" },
-        "MediaPlayPause": { "Italiano (Italian)": "Pausa riproduzione media" },
-        "LaunchMail": { "Italiano (Italian)": "Esegui programma mail" },
-        "SelectMedia": { "Italiano (Italian)": "Seleziona media" },
-        "LaunchApplication1": { "Italiano (Italian)": "Esegui applicazione1" },
-        "LaunchApplication2": { "Italiano (Italian)": "Esegui applicazione2" },
-        "Semicolon": { "Italiano (Italian)": "Punto e virgola" },
-        "Equals": { "Italiano (Italian)": "Uguale" },
-        "Comma": { "Italiano (Italian)": "Virgola" },
-        "Dash": { "Italiano (Italian)": "Trattino" },
-        "Period": { "Italiano (Italian)": "Punto" },
-        "ForwardSlash": { "Italiano (Italian)": "Slash" },
-        "Grave": { "Italiano (Italian)": "Grave" },
-        "OpenBracket": { "Italiano (Italian)": "ParenetsiAperta" },
-        "BackSlash": { "Italiano (Italian)": "Backslash" },
-        "CloseBracket": { "Italiano (Italian)": "ParentesiChiusa" },
-        "Quote": { "Italiano (Italian)": "Virgolette" },
-        "Oem8": { "Italiano (Italian)": "Oem8" },
-        "OemBackslash": { "Italiano (Italian)": "BackslashOem" },
-        "ImeProcess": { "Italiano (Italian)": "ImeProcess" },
-        "Attn": { "Italiano (Italian)": "Attn" },
-        "CrSel": { "Italiano (Italian)": "CrSel" },
-        "ExSel": { "Italiano (Italian)": "ExSel" },
-        "EraseEof": { "Italiano (Italian)": "EliminaEof" },
-        "Play": { "Italiano (Italian)": "Riproduci" },
-        "Zoom": { "Italiano (Italian)": "Zoom" },
-        "Pa1": { "Italiano (Italian)": "Pa1" },
-        "OemClear": { "Italiano (Italian)": "AzzeraOem" },
-        "ImeKanaMode": { "Italiano (Italian)": "ImeModoKana" },
-        "ImeJunjaMode": { "Italiano (Italian)": "ImeModoJunja" },
-        "ImeFinalMode": { "Italiano (Italian)": "ImeModoFinal" },
-        "ImeHanjaMode": { "Italiano (Italian)": "ImeModoHanja" },
-        "ImeConvert": { "Italiano (Italian)": "ImeConvert" },
-        "ImeNonConvert": { "Italiano (Italian)": "ImeNonConvert" },
-        "ImeAccept": { "Italiano (Italian)": "ImeAccetta" },
-        "ImeModeChange": { "Italiano (Italian)": "ImemCambiaModo" }
-  
+
+    "ListNotification": {
+      "Options": {
+        "Header": "Opciones",
+        "ShowControls": {
+          "Content": "Mostrar controles",
+          "Tooltip": "Alterna la visibilidad de los controles avanzados junto a los elementos de la lista."
+        },
+        "DragRequiresAlt": {
+          "Content": "Arrastrar requiere 'Alt'",
+          "Tooltip": "Si esta opción está seleccionada, se debe mantener presionada la tecla 'Alt' para arrastrar la ventana de notificaciones."
+        },
+        "SavePosition": {
+          "Content": "Guardar posición",
+          "Tooltip": {}
+        },
+        "DoFadeIn": {
+          "Content": "Desvanecer (entrada)",
+          "Tooltip": "Si esta opción está seleccionada, la ventana de notificaciones muestra una animación de desvanecimiento en lugar de aparecer de inmediato."
+        },
+        "FadeInDuration": {
+          "Tooltip": "Especifica la duración de la animación de desvanecimiento en milisegundos."
+        },
+        "DoFadeOut": {
+          "Content": "Desvanecer (salida)",
+          "Tooltip": "Si esta opción está seleccionada, la ventana de notificaciones muestra una animación de desvanecimiento en lugar de desaparecer de inmediato."
+        },
+        "FadeOutDuration": {
+          "Tooltip": "Especifica la duración de la animación de desvanecimiento en milisegundos."
+        }
       }
     },
-  
-    "DefaultHotkeyNames": {
-      "Volume Up": "Volume +",
-      "Volume Down": "Volume -",
-      "Toggle Mute": "Audio OFF/ON",
-      "Next Session": "Sessione successiva",
-      "Previous Session": "Sessione precedente",
-      "Un/Lock Session": {
-        "Italiano (Italian)": "Sblocca/blocca sessione"
+
+    "ActionSettingsWindow": {
+      "DataTemplateErrorTextBlock": {
+        "Tooltip": "¡No hay una plantilla de datos disponible para este tipo de valor!"
       },
-      "Toggle Selected": "Selezionati ON/OFF"
+      "ToggleActionSetting": {
+        "Content": "Habilitar",
+        "Tooltip": "Esta opción de acción se habilita cuando está marcada."
+      },
+      "ActionTargetSpecifierDataTemplate": {
+        "AddTargetBox": {
+          "DefaultText": "Nombre del destino..."
+        }
+      }
+    },
+
+    "Dialogs": {
+      "AnotherInstanceIsRunning": {
+        "MultiInstance": "¡Otra instancia de Volume Control está utilizando el archivo de configuración ubicado en '${PATH}'!",
+        "SingleInstance": "¡Otra instancia de Volume Control ya está en ejecución!"
+      },
+      "UpdatePrompt": {
+        "DontShowInFutureMsg": "No se mostrarán las notificaciones de actualización en el futuro.",
+        "NewVersionAvailableMessage": "¡Hay una nueva versión de Volume Control disponible!\n¿Quieres ir a la página de lanzamientos?\nVersión actual: ${CURRENT_VERSION}\nÚltima versión: ${LATEST_VERSION}",
+        "NewVersionAvailableOptions_AutoUpdate": "Haz clic en 'Sí' para instalar la última versión.\nHaz clic en 'No' si no deseas actualizar ahora.\nHaz clic en 'Cancelar' para desactivar estas notificaciones.",
+        "NewVersionAvailableOptions_OpenBrowser": "Haz clic en 'Sí' para ir a la página de lanzamientos.\nHaz clic en 'No' si no deseas actualizar ahora.\nHaz clic en 'Cancelar' para desactivar estas notificaciones.",
+        "DownloadFailed": {
+          "Caption": "Descarga fallida",
+          "Message": "Ocurrió un error al descargar el instalador, revisa el registro para más información.\n¿Quieres abrir la página de lanzamientos?"
+        },
+        "StartFailed": {
+          "Caption": "No se pudo iniciar el instalador",
+          "Message": "No se pudo iniciar el instalador\nNo se pudo iniciar el instalador, pero se descargó con éxito.\nEs posible que los permisos de tu sistema no permitan ejecutar aplicaciones desde la carpeta de descargas.\n\nTendrás que iniciar el instalador manualmente."
+        }
+      },
+      "ResetHotkeys": {
+        "Message": "¿Estás seguro de que quieres restablecer todos los atajos a sus valores predeterminados?\n\n¡Esto no se puede deshacer!",
+        "Caption": "¿Restablecer atajos?"
+      },
+      "RemoveHotkey": {
+        "Message": "¿Estás seguro de que deseas eliminar el atajo ${ID}?\n\n- 'Sí' Eliminar el atajo.\n- 'No' No eliminar el atajo.\n- 'Cancelar' No mostrar esto de nuevo. (Presiona de nuevo para eliminar)",
+        "Caption": "Confirmar eliminación"
+      },
+      "MultiInstanceChanged": {
+        "Message": "Los cambios en la configuración de Multi-Instancias tendrán efecto después de reiniciar Volume Control.\n\n¿Quieres reiniciar la aplicación ahora?",
+        "Caption": "Reinicio de la aplicación necesario"
+      }
+    },
+
+    "NotifyIcon": {
+      "BringToFront": "Traer al frente",
+      "Hide": "Ocultar",
+      "Show": "Mostrar",
+      "OpenLocation": "Abrir ubicación",
+      "OpenAppData": "Abrir AppDatta",
+      "Close": "Cerrar"
     }
+  },
+
+  "Enums": {
+    "ENotificationViewMode": {
+      "ControlBar": "Barra de control",
+      "SelectedItemOnly": "Sólo elementos seleccionados",
+      "AllItems": "Todos los elementos"
+    },
+    "EFriendlyKey": {
+      "None": { "Español (Spain)": "Ninguno" },
+      "Cancel": { "Español (Spain)": "Cancelar" },
+      "Backspace": { "Español (Spain)": "Retroceso" },
+      "Tab": { "Español (Spain)": "Tabulador" },
+      "Clear": { "Español (Spain)": "Borrar" },
+      "Enter": { "Español (Spain)": "Entrar" },
+      "PauseBreak": { "Español (Spain)": "Pausa/Interrumpir" },
+      "CapsLock": { "Español (Spain)": "Bloq Mayús" },
+      "Escape": { "Español (Spain)": "Esc" },
+      "Space": { "Español (Spain)": "Espacio" },
+      "PageUp": { "Español (Spain)": "Re Pág" },
+      "PageDown": { "Español (Spain)": "Av Pág" },
+      "End": { "Español (Spain)": "Fin" },
+      "Home": { "Español (Spain)": "Inicio" },
+      "LeftArrow": { "Español (Spain)": "Flecha Izquierda" },
+      "UpArrow": { "Español (Spain)": "Flecha Arriba" },
+      "RightArrow": { "Español (Spain)": "Flecha Derecha" },
+      "DownArrow": { "Español (Spain)": "Flecha Abajo" },
+      "Select": { "Español (Spain)": "Seleccionar" },
+      "Print": { "Español (Spain)": "Imprimir" },
+      "Execute": { "Español (Spain)": "Ejecutar" },
+      "PrintScreen": { "Español (Spain)": "Imprimir Pantalla" },
+      "Insert": { "Español (Spain)": "Insertar" },
+      "Delete": { "Español (Spain)": "Suprimir" },
+      "Help": { "Español (Spain)": "Ayuda" },
+      "D0": { "Español (Spain)": "0" },
+      "D1": { "Español (Spain)": "1" },
+      "D2": { "Español (Spain)": "2" },
+      "D3": { "Español (Spain)": "3" },
+      "D4": { "Español (Spain)": "4" },
+      "D5": { "Español (Spain)": "5" },
+      "D6": { "Español (Spain)": "6" },
+      "D7": { "Español (Spain)": "7" },
+      "D8": { "Español (Spain)": "8" },
+      "D9": { "Español (Spain)": "9" },
+      "A": { "Español (Spain)": "A" },
+      "B": { "Español (Spain)": "B" },
+      "C": { "Español (Spain)": "C" },
+      "D": { "Español (Spain)": "D" },
+      "E": { "Español (Spain)": "E" },
+      "F": { "Español (Spain)": "F" },
+      "G": { "Español (Spain)": "G" },
+      "H": { "Español (Spain)": "H" },
+      "I": { "Español (Spain)": "I" },
+      "J": { "Español (Spain)": "J" },
+      "K": { "Español (Spain)": "K" },
+      "L": { "Español (Spain)": "L" },
+      "M": { "Español (Spain)": "M" },
+      "N": { "Español (Spain)": "N" },
+      "O": { "Español (Spain)": "O" },
+      "P": { "Español (Spain)": "P" },
+      "Q": { "Español (Spain)": "Q" },
+      "R": { "Español (Spain)": "R" },
+      "S": { "Español (Spain)": "S" },
+      "T": { "Español (Spain)": "T" },
+      "U": { "Español (Spain)": "U" },
+      "V": { "Español (Spain)": "V" },
+      "W": { "Español (Spain)": "W" },
+      "X": { "Español (Spain)": "X" },
+      "Y": { "Español (Spain)": "Y" },
+      "Z": { "Español (Spain)": "Z" },
+      "Apps": { "Español (Spain)": "Aplicaciones" },
+      "Sleep": { "Español (Spain)": "Suspender" },
+      "NumPad0": { "Español (Spain)": "Numpad 0" },
+      "NumPad1": { "Español (Spain)": "Numpad 1" },
+      "NumPad2": { "Español (Spain)": "Numpad 2" },
+      "NumPad3": { "Español (Spain)": "Numpad 3" },
+      "NumPad4": { "Español (Spain)": "Numpad 4" },
+      "NumPad5": { "Español (Spain)": "Numpad 5" },
+      "NumPad6": { "Español (Spain)": "Numpad 6" },
+      "NumPad7": { "Español (Spain)": "Numpad 7" },
+      "NumPad8": { "Español (Spain)": "Numpad 8" },
+      "NumPad9": { "Español (Spain)": "Numpad 9" },
+      "NumPadMultiply": { "Español (Spain)": "Numpad *" },
+      "NumPadAdd": { "Español (Spain)": "Numpad +" },
+      "Separator": { "Español (Spain)": "Separador" },
+      "NumPadSubtract": { "Español (Spain)": "Numpad -" },
+      "NumPadDecimal": { "Español (Spain)": "Numpad ." },
+      "NumPadDivide": { "Español (Spain)": "Numpad /" },
+      "F1": { "Español (Spain)": "F1" },
+      "F2": { "Español (Spain)": "F2" },
+      "F3": { "Español (Spain)": "F3" },
+      "F4": { "Español (Spain)": "F4" },
+      "F5": { "Español (Spain)": "F5" },
+      "F6": { "Español (Spain)": "F6" },
+      "F7": { "Español (Spain)": "F7" },
+      "F8": { "Español (Spain)": "F8" },
+      "F9": { "Español (Spain)": "F9" },
+      "F10": { "Español (Spain)": "F10" },
+      "F11": { "Español (Spain)": "F11" },
+      "F12": { "Español (Spain)": "F12" },
+      "F13": { "Español (Spain)": "F13" },
+      "F14": { "Español (Spain)": "F14" },
+      "F15": { "Español (Spain)": "F15" },
+      "F16": { "Español (Spain)": "F16" },
+      "F17": { "Español (Spain)": "F17" },
+      "F18": { "Español (Spain)": "F18" },
+      "F19": { "Español (Spain)": "F19" },
+      "F20": { "Español (Spain)": "F20" },
+      "F21": { "Español (Spain)": "F21" },
+      "F22": { "Español (Spain)": "F22" },
+      "F23": { "Español (Spain)": "F23" },
+      "F24": { "Español (Spain)": "F24" },
+      "NumLock": { "Español (Spain)": "NumLock" },
+      "ScrollLock": { "Español (Spain)": "ScrollLock" },
+      "BrowserBack": { "Español (Spain)": "Navegar Atrás" },
+      "BrowserForward": { "Español (Spain)": "Navegar Adelante" },
+      "BrowserRefresh": { "Español (Spain)": "Refrescar" },
+      "BrowserStop": { "Español (Spain)": "Detener" },
+      "BrowserSearch": { "Español (Spain)": "Buscar" },
+      "BrowserFavorites": { "Español (Spain)": "Favoritos" },
+      "BrowserHome": { "Español (Spain)": "Inicio" },
+      "VolumeMute": { "Español (Spain)": "Silenciar" },
+      "VolumeDown": { "Español (Spain)": "Bajar Volumen" },
+      "VolumeUp": { "Español (Spain)": "Subir Volumen" },
+      "MediaNextTrack": { "Español (Spain)": "Siguiente Pista" },
+      "MediaPreviousTrack": { "Español (Spain)": "Pista Anterior" },
+      "MediaStop": { "Español (Spain)": "Detener Multimedia" },
+      "MediaPlayPause": { "Español (Spain)": "Reproducir/Pausar" },
+      "LaunchMail": { "Español (Spain)": "Abrir Correo" },
+      "SelectMedia": { "Español (Spain)": "Seleccionar Multimedia" },
+      "LaunchApplication1": { "Español (Spain)": "Abrir Aplicación 1" },
+      "LaunchApplication2": { "Español (Spain)": "Abrir Aplicación 2" },
+      "Semicolon": { "Español (Spain)": "Punto y Coma" },
+      "Equals": { "Español (Spain)": "Igual" },
+      "Comma": { "Español (Spain)": "Coma" },
+      "Dash": { "Español (Spain)": "Guión" },
+      "Period": { "Español (Spain)": "Punto" },
+      "ForwardSlash": { "Español (Spain)": "Barra" },
+      "Grave": { "Español (Spain)": "Acento Grave" },
+      "OpenBracket": { "Español (Spain)": "Corchete Abierto" },
+      "BackSlash": { "Español (Spain)": "Barra Invertida" },
+      "CloseBracket": { "Español (Spain)": "Corchete Cerrado" },
+      "Quote": { "Español (Spain)": "Comillas" },
+      "Oem8": { "Español (Spain)": "Oem8" },
+      "OemBackslash": { "Español (Spain)": "Barra Invertida Oem" },
+      "ImeProcess": { "Español (Spain)": "Proceso Ime" },
+      "Attn": { "Español (Spain)": "Atención" },
+      "CrSel": { "Español (Spain)": "CrSel" },
+      "ExSel": { "Español (Spain)": "ExSel" },
+      "EraseEof": { "Español (Spain)": "Borrar Fin" },
+      "Play": { "Español (Spain)": "Reproducir" },
+      "Zoom": { "Español (Spain)": "Acercar" },
+      "Pa1": { "Español (Spain)": "Pa1" },
+      "OemClear": { "Español (Spain)": "OemClear" },
+      "ImeKanaMode": { "Español (Spain)": "Modo Ime Kana" },
+      "ImeJunjaMode": { "Español (Spain)": "Modo Ime Junja" },
+      "ImeFinalMode": { "Español (Spain)": "Modo Ime Final" },
+      "ImeHanjaMode": { "Español (Spain)": "Modo Ime Hanja" },
+      "ImeConvert": { "Español (Spain)": "Convertir Ime" },
+      "ImeNonConvert": { "Español (Spain)": "No Convertir Ime" },
+      "ImeAccept": { "Español (Spain)": "Aceptar Ime" },
+      "ImeModeChange": { "Español (Spain)": "Cambiar Modo Ime" }
+    }
+  },
+
+  "DefaultHotkeyNames": {
+    "Volume Up": "Subir volumen",
+    "Volume Down": "Bajar volumen",
+    "Toggle Mute": "Silenciar",
+    "Next Session": "Siguiente sesión",
+    "Previous Session": "Sesión anterior",
+    "Un/Lock Session": {
+      "Italiano (Italian)": "(Des)bloquear sesión"
+    },
+    "Toggle Selected": "Alternar seleccionado"
   }
+}

--- a/VolumeControl/Localization/es.loc.json
+++ b/VolumeControl/Localization/es.loc.json
@@ -568,7 +568,7 @@
     "Next Session": "Siguiente sesión",
     "Previous Session": "Sesión anterior",
     "Un/Lock Session": {
-      "Italiano (Italian)": "(Des)bloquear sesión"
+      "Español (Spain)": "(Des)bloquear sesión"
     },
     "Toggle Selected": "Alternar seleccionado"
   }


### PR DESCRIPTION
Hi, so I added a new .json with all of the translations to Spanish (from Spain). I also tested it in order to embedd it and it works almost perfectly, let me explain:

Everything in the only .json file i modified looks fine, when testing i saw that the FadeInDuration tooltip is not being translated in any language. Same thing happens with all the hotkeys from the list.

Thats why im sending this without doing the embed, so I don't screw up anything (i'm quite new into all of this)

I hope Spanish gets implemented soon, lots of friends that have it as me, and we would love the translation, thats why i made one :)

Btw, huge app, makes everything much easier ❤️